### PR TITLE
ci: make populating Cachix the workflows' primary goal

### DIFF
--- a/.github/workflows/build-darwin.yml
+++ b/.github/workflows/build-darwin.yml
@@ -81,8 +81,10 @@ jobs:
       # different store path and warm nothing.
       - name: Pre-warm ${{ matrix.attr }}
         id: prewarm
+        # 300 not 330: leaves the same ~50-minute tail as build-darwin for
+        # the backstop push, which on a cold store has real work to do.
         continue-on-error: true
-        timeout-minutes: 330
+        timeout-minutes: 300
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
@@ -115,7 +117,7 @@ jobs:
           fi
 
       - name: Push ${{ matrix.attr }} to Cachix
-        if: (success() || failure()) && steps.cachix_setup.outcome == 'success'
+        if: always() && steps.cachix_setup.outcome == 'success'
         continue-on-error: true
         env:
           CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -237,15 +239,22 @@ jobs:
       # never fail the job on its own (e.g. the 2026-07-08 "Error: not found:
       # cachix" incident).
       #
-      # (success() || failure()) rather than a plain success gate: salvaging a
-      # broken run is the whole point. If the build or the flake check failed,
-      # everything that DID build is still valid in the local store and still
-      # worth caching - dropping it makes the next run rebuild it from
-      # scratch. Deliberately NOT always(): a cancelled run (concurrency,
-      # manual) is killed mid-build and its store is not worth uploading.
+      # always(), not a success/failure gate: salvaging a broken run is the
+      # whole point. Whatever DID build is still valid in the local store and
+      # still worth caching - dropping it makes the next run rebuild it from
+      # scratch.
+      #
+      # Cancellation is included deliberately. cancel-in-progress fires often
+      # here (5 of 12 recent build.yml runs, 2 of 12 darwin runs), and run 1095
+      # shows always() steps really do execute in the grace window before the
+      # runner shuts down - it got roughly eleven minutes. That is the one
+      # difference from Save Nix Store Cache below, which stays off cancelled
+      # runs on purpose: a store snapshot taken mid-build is internally
+      # inconsistent, whereas Cachix uploads whole valid paths one at a time,
+      # so a push cut short just means fewer paths, never a corrupt cache.
       - name: Push to Cachix (Darwin)
         id: cachix_push
-        if: (success() || failure()) && steps.cachix_setup.outcome == 'success'
+        if: always() && steps.cachix_setup.outcome == 'success'
         continue-on-error: true
         env:
           CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -277,14 +286,15 @@ jobs:
           echo "No toplevel output path - pushing every valid store path instead."
           nix path-info --all | grep -v '\.drv$' | cachix push ${{ env.CACHIX_NAME }}
 
+      # No `du -sh /nix/store` here - see the matching step in build.yml.
+      # It cost 2m49s on run 754 and over ten minutes on a large Linux store,
+      # delaying the steps that actually persist anything. df is instant.
       - name: Check Disk Usage
         if: always()
         continue-on-error: true
         run: |
           echo "--- Disk Space Usage ---"
           df -h
-          echo "--- Nix Store Size ---"
-          du -sh /nix/store
 
       - name: Show Package Tree (Darwin)
         if: always()

--- a/.github/workflows/build-darwin.yml
+++ b/.github/workflows/build-darwin.yml
@@ -20,124 +20,6 @@ concurrency:
 
 jobs:
   # ===========================================================================
-  # JOB: Pre-warm the heavy aarch64-darwin packages
-  # ===========================================================================
-  # Runs in PARALLEL with build-darwin, deliberately not as a `needs:`
-  # dependency. These packages are the ones that don't fit in a single job's
-  # budget, so gating the main build on them would just stall the thing that
-  # populates most of the cache.
-  #
-  # Why this job exists: run 754 spent its entire 300-minute budget on
-  # thunderbird-unwrapped, which nixpkgs does not ship prebuilt for
-  # aarch64-darwin (Nix chose to build it rather than substitute it), and a
-  # 3-core macOS runner cannot finish a Thunderbird build inside GitHub's
-  # 360-minute hard job cap. Left in the main build it consumes one of two
-  # --max-jobs slots for the whole run, every run.
-  #
-  # Here it gets its own budget and its own runner, and because the build runs
-  # under `cachix watch-exec` every dependency it completes is pushed
-  # immediately. So even a leg that times out advances the chain: the next run
-  # substitutes what this one built and starts further along. Add attrs to the
-  # matrix as new heavy darwin packages appear.
-  prewarm-darwin:
-    runs-on: macos-15
-    timeout-minutes: 350
-    continue-on-error: true
-    permissions:
-      contents: read
-      id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        attr:
-          - thunderbird
-    env:
-      NIXPKGS_ALLOW_UNFREE: 1
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-        with:
-          flakehub: false
-          extra-conf: |
-            auto-optimise-store = true
-            experimental-features = nix-command flakes
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Cachix
-        id: cachix_setup
-        continue-on-error: true
-        env:
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        run: |
-          nix profile install --accept-flake-config nixpkgs#cachix
-          cachix use ${{ env.CACHIX_NAME }}
-
-      # Built through the host's own pkgs instance rather than plain
-      # nixpkgs#<attr>, so this is the exact derivation build-darwin would
-      # otherwise build (same overlays, unfree allowance, system) - not a
-      # look-alike from a different nixpkgs instantiation that would land on a
-      # different store path and warm nothing.
-      - name: Pre-warm ${{ matrix.attr }}
-        id: prewarm
-        # 300 not 330: leaves the same ~50-minute tail as build-darwin for
-        # the backstop push, which on a cold store has real work to do.
-        continue-on-error: true
-        timeout-minutes: 300
-        env:
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        run: |
-          ATTR='.#darwinConfigurations.Krits-MacBook-Pro.pkgs.${{ matrix.attr }}'
-
-          # Self-diagnosing guard: denix generates darwinConfigurations, and if
-          # a future denix/nix-darwin release stops exposing `.pkgs` this leg
-          # would otherwise fail identically on every run with a confusing
-          # error. Skip cleanly and say so instead.
-          if ! nix eval --raw "$ATTR.drvPath" > /dev/null 2>&1; then
-            echo "::warning::$ATTR does not evaluate - skipping this pre-warm leg."
-            exit 0
-          fi
-
-          # Probe first: `cachix watch-exec` failing would be indistinguishable
-          # from the build failing, and a cachix problem must never be reported
-          # as a broken config. If the subcommand isn't usable, build plainly -
-          # the end-of-job push still populates the cache either way.
-          WATCH=0
-          if [ "${{ steps.cachix_setup.outcome }}" = "success" ] && [ -n "$CACHIX_AUTH_TOKEN" ] \
-             && cachix watch-exec --help > /dev/null 2>&1; then
-            WATCH=1
-          fi
-          BUILD="nix build $ATTR --no-link --print-out-paths --keep-going --max-jobs 2 --cores 4 > out.txt"
-          if [ "$WATCH" = 1 ]; then
-            echo "Building under 'cachix watch-exec' - paths are pushed as they are built."
-            cachix watch-exec ${{ env.CACHIX_NAME }} -- bash -c "$BUILD"
-          else
-            bash -c "$BUILD"
-          fi
-
-      - name: Push ${{ matrix.attr }} to Cachix
-        if: always() && steps.cachix_setup.outcome == 'success'
-        continue-on-error: true
-        env:
-          CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        run: |
-          if [ -z "$CACHIX_TOKEN" ]; then
-            echo "Skipping Cachix push: no auth token found (likely a fork)."
-            exit 0
-          fi
-
-          if [ -s out.txt ]; then
-            cachix push ${{ env.CACHIX_NAME }} $(cat out.txt)
-            exit 0
-          fi
-
-          # Backstop for whatever watch-exec's hook didn't cover.
-          echo "No output path for ${{ matrix.attr }} - pushing every valid store path instead."
-          nix path-info --all | grep -v '\.drv$' | cachix push ${{ env.CACHIX_NAME }}
-
-  # ===========================================================================
   # JOB: Build aarch64-darwin (MacBook Pro)
   # ===========================================================================
   build-darwin:
@@ -162,6 +44,25 @@ jobs:
             auto-optimise-store = true
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            # Auto-GC during the build. macOS runners share one APFS container
+            # and start with only ~40 GiB free, which is the real ceiling on a
+            # cold darwin build: run 754 reached 38 GiB of store with 1.4 GiB
+            # left (disk 100% full) and then produced no output at all for five
+            # hours until the step timeout killed it. When free space drops
+            # below min-free, Nix collects unreferenced paths until max-free is
+            # available again, instead of wedging on a full disk.
+            #
+            # Safe here in a way it would not be in build.yml: that workflow
+            # sets keep-outputs/keep-derivations on purpose, to stop a saved
+            # store cache from referencing pruned files (the 2026-07-07
+            # "user-environment.drv does not exist" failure), and auto-GC would
+            # work against it - while having nothing to fix, since
+            # nothing-but-nix leaves that job ~78 GiB free. Darwin has no store
+            # cache to protect. Anything GC removes here has already been
+            # uploaded by watch-exec, so the worst case is re-substituting it
+            # from our own cache.
+            min-free = 5000000000
+            max-free = 15000000000
 
       # Non-critical: only used to speed up this job and to push the build
       # output below. A failed install must not fail the whole job - the
@@ -197,6 +98,14 @@ jobs:
       #   timeout, was killed, and the push step was skipped - five hours of
       #   macOS build time discarded. With watch-exec every path that finished
       #   in those five hours would already have been in the cache.
+      #
+      # That run was building thunderbird-unwrapped-153.0.1 during a window
+      # where nixpkgs had bumped but Hydra had not yet published the darwin
+      # build, so it compiled locally and filled the disk (1.4 GiB left at the
+      # timeout). Two days later 153.0.2 substituted from cache.nixos.org in
+      # eight minutes. Cold builds like that are rare but they are exactly
+      # when the cache matters most, and exactly when the run is most likely
+      # to die before reaching the end of the job.
       #
       # It also means successive runs make incremental progress through a long
       # dependency chain: each run substitutes what earlier runs pushed and

--- a/.github/workflows/build-darwin.yml
+++ b/.github/workflows/build-darwin.yml
@@ -20,6 +20,122 @@ concurrency:
 
 jobs:
   # ===========================================================================
+  # JOB: Pre-warm the heavy aarch64-darwin packages
+  # ===========================================================================
+  # Runs in PARALLEL with build-darwin, deliberately not as a `needs:`
+  # dependency. These packages are the ones that don't fit in a single job's
+  # budget, so gating the main build on them would just stall the thing that
+  # populates most of the cache.
+  #
+  # Why this job exists: run 754 spent its entire 300-minute budget on
+  # thunderbird-unwrapped, which nixpkgs does not ship prebuilt for
+  # aarch64-darwin (Nix chose to build it rather than substitute it), and a
+  # 3-core macOS runner cannot finish a Thunderbird build inside GitHub's
+  # 360-minute hard job cap. Left in the main build it consumes one of two
+  # --max-jobs slots for the whole run, every run.
+  #
+  # Here it gets its own budget and its own runner, and because the build runs
+  # under `cachix watch-exec` every dependency it completes is pushed
+  # immediately. So even a leg that times out advances the chain: the next run
+  # substitutes what this one built and starts further along. Add attrs to the
+  # matrix as new heavy darwin packages appear.
+  prewarm-darwin:
+    runs-on: macos-15
+    timeout-minutes: 350
+    continue-on-error: true
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        attr:
+          - thunderbird
+    env:
+      NIXPKGS_ALLOW_UNFREE: 1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          flakehub: false
+          extra-conf: |
+            auto-optimise-store = true
+            experimental-features = nix-command flakes
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Cachix
+        id: cachix_setup
+        continue-on-error: true
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          nix profile install --accept-flake-config nixpkgs#cachix
+          cachix use ${{ env.CACHIX_NAME }}
+
+      # Built through the host's own pkgs instance rather than plain
+      # nixpkgs#<attr>, so this is the exact derivation build-darwin would
+      # otherwise build (same overlays, unfree allowance, system) - not a
+      # look-alike from a different nixpkgs instantiation that would land on a
+      # different store path and warm nothing.
+      - name: Pre-warm ${{ matrix.attr }}
+        id: prewarm
+        continue-on-error: true
+        timeout-minutes: 330
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          ATTR='.#darwinConfigurations.Krits-MacBook-Pro.pkgs.${{ matrix.attr }}'
+
+          # Self-diagnosing guard: denix generates darwinConfigurations, and if
+          # a future denix/nix-darwin release stops exposing `.pkgs` this leg
+          # would otherwise fail identically on every run with a confusing
+          # error. Skip cleanly and say so instead.
+          if ! nix eval --raw "$ATTR.drvPath" > /dev/null 2>&1; then
+            echo "::warning::$ATTR does not evaluate - skipping this pre-warm leg."
+            exit 0
+          fi
+
+          # Probe first: `cachix watch-exec` failing would be indistinguishable
+          # from the build failing, and a cachix problem must never be reported
+          # as a broken config. If the subcommand isn't usable, build plainly -
+          # the end-of-job push still populates the cache either way.
+          WATCH=0
+          if [ "${{ steps.cachix_setup.outcome }}" = "success" ] && [ -n "$CACHIX_AUTH_TOKEN" ] \
+             && cachix watch-exec --help > /dev/null 2>&1; then
+            WATCH=1
+          fi
+          BUILD="nix build $ATTR --no-link --print-out-paths --keep-going --max-jobs 2 --cores 4 > out.txt"
+          if [ "$WATCH" = 1 ]; then
+            echo "Building under 'cachix watch-exec' - paths are pushed as they are built."
+            cachix watch-exec ${{ env.CACHIX_NAME }} -- bash -c "$BUILD"
+          else
+            bash -c "$BUILD"
+          fi
+
+      - name: Push ${{ matrix.attr }} to Cachix
+        if: (success() || failure()) && steps.cachix_setup.outcome == 'success'
+        continue-on-error: true
+        env:
+          CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          if [ -z "$CACHIX_TOKEN" ]; then
+            echo "Skipping Cachix push: no auth token found (likely a fork)."
+            exit 0
+          fi
+
+          if [ -s out.txt ]; then
+            cachix push ${{ env.CACHIX_NAME }} $(cat out.txt)
+            exit 0
+          fi
+
+          # Backstop for whatever watch-exec's hook didn't cover.
+          echo "No output path for ${{ matrix.attr }} - pushing every valid store path instead."
+          nix path-info --all | grep -v '\.drv$' | cachix push ${{ env.CACHIX_NAME }}
+
+  # ===========================================================================
   # JOB: Build aarch64-darwin (MacBook Pro)
   # ===========================================================================
   build-darwin:
@@ -57,21 +173,65 @@ jobs:
           nix profile install --accept-flake-config nixpkgs#cachix
           cachix use ${{ env.CACHIX_NAME }}
 
+      # continue-on-error: the flake check is this workflow's SECONDARY goal.
+      # It validates every flake output - other hosts, homeConfigurations, the
+      # formatter - so it can fail for reasons that have nothing to do with
+      # whether THIS host builds. Letting it abort the job would skip the
+      # build and the Cachix push, which are the primary goal. Its outcome is
+      # re-asserted by the status gate near the end of the job, so a real
+      # failure still turns the check red and fires the Discord notice - just
+      # after the cache has been populated rather than instead of it.
       - name: Check Flake
+        id: flake_check
+        continue-on-error: true
         run: nix flake check --impure --show-trace
 
+      # Wrapped in `cachix watch-exec`, which registers a Nix post-build hook
+      # and uploads each store path the moment it is built, in parallel with
+      # the rest of the build. This is what makes the cache survive a run that
+      # never reaches the push step at the end:
+      #
+      #   run 754 (2026-08-16) built for exactly 300m13s, hit this step's
+      #   timeout, was killed, and the push step was skipped - five hours of
+      #   macOS build time discarded. With watch-exec every path that finished
+      #   in those five hours would already have been in the cache.
+      #
+      # It also means successive runs make incremental progress through a long
+      # dependency chain: each run substitutes what earlier runs pushed and
+      # then builds further, instead of restarting from the same place.
+      #
+      # Nix does not fire the hook for substituted paths, so this uploads only
+      # what was actually built here. The end-of-job push below stays as a
+      # backstop for anything the hook missed.
+      #
+      # --keep-going: when a derivation fails (broken dep, unfree, or a package
+      # whose meta.platforms excludes aarch64-darwin) keep building every other
+      # branch of the graph, so one bad package doesn't cost us the closure.
       - name: Build Darwin Configuration
         id: build
-        # --keep-going: when a derivation fails (broken dep, unfree, or a
-        # package whose meta.platforms excludes aarch64-darwin) keep building
-        # every other branch of the graph, so one bad package doesn't cost us
-        # the whole closure. The push step below runs regardless of this
-        # step's outcome and uploads whatever did build - so a partial
-        # failure still fails the job (the red check is the signal that
-        # something needs fixing) without throwing the build away.
         timeout-minutes: 300
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
-          nix build .#darwinConfigurations.Krits-MacBook-Pro.system --no-link --print-out-paths --keep-going --max-jobs 2 --cores 4 > outpaths.txt
+          # Redirect inside the inner shell so outpaths.txt gets Nix's stdout
+          # only, never watch-exec's own progress output.
+          # Probe first: `cachix watch-exec` failing would be indistinguishable
+          # from the build failing, and a cachix problem must never be reported
+          # as a broken config. If the subcommand isn't usable, build plainly -
+          # the end-of-job push still populates the cache either way.
+          WATCH=0
+          if [ "${{ steps.cachix_setup.outcome }}" = "success" ] && [ -n "$CACHIX_AUTH_TOKEN" ] \
+             && cachix watch-exec --help > /dev/null 2>&1; then
+            WATCH=1
+          fi
+          BUILD='nix build .#darwinConfigurations.Krits-MacBook-Pro.system --no-link --print-out-paths --keep-going --max-jobs 2 --cores 4 > outpaths.txt'
+          if [ "$WATCH" = 1 ]; then
+            echo "Building under 'cachix watch-exec' - paths are pushed as they are built."
+            cachix watch-exec ${{ env.CACHIX_NAME }} -- bash -c "$BUILD"
+          else
+            echo "Cachix unavailable - building without continuous push."
+            bash -c "$BUILD"
+          fi
 
       # Pushing to the binary cache is a non-critical secondary goal: it must
       # never fail the job on its own (e.g. the 2026-07-08 "Error: not found:
@@ -136,13 +296,28 @@ jobs:
             echo "No output paths were built."
           fi
 
+      # The flake check is continue-on-error so it cannot skip the build and
+      # the push. Re-assert its outcome here - after the cache is populated -
+      # so a real failure still shows a red check and fires the notice below.
+      # The build step is NOT continue-on-error: it fails the job directly,
+      # and every step between it and here carries a status function so they
+      # all still run.
+      - name: Report Job Status
+        if: always()
+        run: |
+          if [ "${{ steps.flake_check.outcome }}" = "failure" ]; then
+            echo "::error::nix flake check failed (build and Cachix push still ran)"
+            exit 1
+          fi
+          echo "flake check: ${{ steps.flake_check.outcome }}, build: ${{ steps.build.outcome }}"
+
       - name: Notify on Failure (Darwin)
         if: failure() && env.WEBHOOK_ID != ''
         continue-on-error: true
         env:
           WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
         run: |
-          jq -n --arg content "🚨 nix-darwin build failed on **aarch64-darwin** (whatever did build was still pushed to Cachix). Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
+          jq -n --arg content "🚨 nix-darwin run failed on **aarch64-darwin** (flake check and/or build - whatever did build was still pushed to Cachix). Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
           curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
 
       # Non-critical infra (cachix setup/push) failing must not fail the

--- a/.github/workflows/build-darwin.yml
+++ b/.github/workflows/build-darwin.yml
@@ -62,37 +62,60 @@ jobs:
 
       - name: Build Darwin Configuration
         id: build
-        # continue-on-error: --keep-going already builds everything it can
-        # even when some derivations fail (unfree/unsupported/broken deps),
-        # so a partial failure here must not skip the Cachix push below -
-        # we want to push whatever DID build, not push nothing. Genuine
-        # partial-failure visibility is handled by the dedicated notify step
-        # further down instead of by failing the job.
-        continue-on-error: true
+        # --keep-going: when a derivation fails (broken dep, unfree, or a
+        # package whose meta.platforms excludes aarch64-darwin) keep building
+        # every other branch of the graph, so one bad package doesn't cost us
+        # the whole closure. The push step below runs regardless of this
+        # step's outcome and uploads whatever did build - so a partial
+        # failure still fails the job (the red check is the signal that
+        # something needs fixing) without throwing the build away.
         timeout-minutes: 300
         run: |
           nix build .#darwinConfigurations.Krits-MacBook-Pro.system --no-link --print-out-paths --keep-going --max-jobs 2 --cores 4 > outpaths.txt
 
-      # Non-critical secondary goal: pushing to the binary cache must never
-      # fail the job on its own (e.g. the 2026-07-08 "Error: not found:
-      # cachix" incident). Gated only on Cachix being set up, not on a clean
-      # build - outpaths.txt can hold partial results from a --keep-going
-      # run that hit some failures, and those are still worth caching.
+      # Pushing to the binary cache is a non-critical secondary goal: it must
+      # never fail the job on its own (e.g. the 2026-07-08 "Error: not found:
+      # cachix" incident).
+      #
+      # (success() || failure()) rather than a plain success gate: salvaging a
+      # broken run is the whole point. If the build or the flake check failed,
+      # everything that DID build is still valid in the local store and still
+      # worth caching - dropping it makes the next run rebuild it from
+      # scratch. Deliberately NOT always(): a cancelled run (concurrency,
+      # manual) is killed mid-build and its store is not worth uploading.
       - name: Push to Cachix (Darwin)
         id: cachix_push
-        if: steps.cachix_setup.outcome == 'success'
+        if: (success() || failure()) && steps.cachix_setup.outcome == 'success'
         continue-on-error: true
         env:
           CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
-          if [ ! -s outpaths.txt ]; then
-            echo "Skipping Cachix push: no output paths were built."
-          elif [ -n "$CACHIX_TOKEN" ]; then
-            cachix push ${{ env.CACHIX_NAME }} $(cat outpaths.txt)
-          else
-            echo "Skipping Cachix push: No auth token found (likely a fork)."
+          if [ -z "$CACHIX_TOKEN" ]; then
+            echo "Skipping Cachix push: no auth token found (likely a fork)."
+            exit 0
           fi
+
+          if [ -s outpaths.txt ]; then
+            # Clean build: push the toplevel closure. Fast and targeted.
+            cachix push ${{ env.CACHIX_NAME }} $(cat outpaths.txt)
+            exit 0
+          fi
+
+          # outpaths.txt is empty. --print-out-paths only prints paths Nix
+          # actually realised, and the toplevel system depends on everything,
+          # so ANY failed derivation leaves the toplevel unrealised and the
+          # file empty - even when --keep-going built thousands of paths
+          # first. Same when evaluation died before the build ran at all.
+          # Skipping the push here is exactly what used to throw away every
+          # partial result and make the next run start cold.
+          #
+          # Pushing the store wholesale is safe: Cachix's upstream-cache
+          # filter (on by default) drops every path already present in
+          # cache.nixos.org, so this uploads only what this repo actually
+          # produced, not a copy of nixpkgs.
+          echo "No toplevel output path - pushing every valid store path instead."
+          nix path-info --all | grep -v '\.drv$' | cachix push ${{ env.CACHIX_NAME }}
 
       - name: Check Disk Usage
         if: always()
@@ -119,21 +142,7 @@ jobs:
         env:
           WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
         run: |
-          jq -n --arg content "🚨 nix-darwin build failed on **aarch64-darwin**! Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
-          curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
-
-      # The build step is now continue-on-error (see its comment), so a
-      # partial --keep-going failure no longer fails the job/triggers the
-      # hard-failure notice above. Surface it here instead so broken
-      # derivations don't go silently unnoticed just because the rest of
-      # the closure built and pushed fine.
-      - name: Notify on Partial Build Failure (Darwin)
-        if: steps.build.outcome == 'failure' && env.WEBHOOK_ID != ''
-        continue-on-error: true
-        env:
-          WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-        run: |
-          jq -n --arg content "⚠️ nix-darwin build had errors on **aarch64-darwin** (some derivations failed) - pushed what succeeded to Cachix. Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
+          jq -n --arg content "🚨 nix-darwin build failed on **aarch64-darwin** (whatever did build was still pushed to Cachix). Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
           curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
 
       # Non-critical infra (cachix setup/push) failing must not fail the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install CA Certificates
+        continue-on-error: true
         run: |
           # Best-effort freshness refresh: ca-certificates is preinstalled on
           # the runner image and Nix uses its own CA bundle (NIX_SSL_CERT_FILE),
@@ -43,9 +44,11 @@ jobs:
           sudo apt-get install -y ca-certificates || true
 
       - name: Set up QEMU
+        continue-on-error: true
         uses: docker/setup-qemu-action@v3
 
       - name: Add Swap
+        continue-on-error: true
         run: |
           # GitHub-hosted runners ship with an active swap file, so fallocate
           # on /swapfile fails with "Text file busy" (ETXTBSY). Disable and
@@ -133,8 +136,36 @@ jobs:
           nix profile install --accept-flake-config nixpkgs#cachix
           cachix use ${{ env.CACHIX_NAME }}
 
+      # continue-on-error so the push below still runs. `nix flake check
+      # --all-systems` realises real derivations (IFD, every host's closure
+      # roots), and until now this job threw all of that away on both success
+      # AND failure - it had no push step at all. Its outcome is re-asserted
+      # by the status gate further down, so a genuine breakage still turns the
+      # job red and fires the Discord notice - just after the cache is warm.
       - name: Check Flake
+        id: flake_check
+        continue-on-error: true
         run: nix flake check --all-systems --show-trace
+
+      # This job builds real store paths and previously cached none of them.
+      # Pushing them means build-x86_64 and the next run substitute instead of
+      # rebuilding. Never fails the job: it is a cache optimisation.
+      - name: Push Flake Check Output to Cachix
+        id: cachix_push
+        if: (success() || failure()) && steps.cachix_setup.outcome == 'success'
+        continue-on-error: true
+        env:
+          CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          if [ -z "$CACHIX_TOKEN" ]; then
+            echo "Skipping Cachix push: no auth token found (likely a fork)."
+            exit 0
+          fi
+          # No single output path to name here - flake check has many roots -
+          # so push the store. Upstream-cache filtering keeps this to what this
+          # run actually produced rather than a copy of nixpkgs.
+          nix path-info --all | grep -v '\.drv$' | cachix push ${{ env.CACHIX_NAME }}
 
       - name: Check for Dead Code (deadnix)
         continue-on-error: true
@@ -158,6 +189,15 @@ jobs:
           jq -n --arg prefix "🧹 **Dead Nix Code Detected (x86_64)** Consider cleaning up:" --arg report "$DEADCODE_REPORT" '{content: ($prefix + "\n```text\n" + $report + "\n```")}' > payload.json
           curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
 
+      - name: Report Flake Check Status
+        if: always()
+        run: |
+          if [ "${{ steps.flake_check.outcome }}" = "failure" ]; then
+            echo "::error::nix flake check failed (its build output was still pushed to Cachix)"
+            exit 1
+          fi
+          echo "flake check: ${{ steps.flake_check.outcome }}"
+
       - name: Notify on Failure (flake check)
         if: failure() && env.WEBHOOK_ID != ''
         continue-on-error: true
@@ -172,7 +212,7 @@ jobs:
       # the hard-failure notice above, which only fires for real flake-check
       # breakage.
       - name: Notify Non-Critical Issues (flake-check)
-        if: success() && env.WEBHOOK_ID != '' && (steps.cache_restore.outcome == 'failure' || steps.cachix_setup.outcome == 'failure')
+        if: success() && env.WEBHOOK_ID != '' && (steps.cache_restore.outcome == 'failure' || steps.cachix_setup.outcome == 'failure' || steps.cachix_push.outcome == 'failure')
         continue-on-error: true
         env:
           WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
@@ -199,7 +239,11 @@ jobs:
   # rebuilds inside build-x86_64 as before.
   prewarm-cache:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 120 rather than 60: a leg killed by the job timeout used to push nothing,
+    # so a package that needed 70 minutes never got cached and every later run
+    # paid for it again. It now pushes continuously (see below), but the extra
+    # headroom lets the slow legs actually finish.
+    timeout-minutes: 120
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -241,11 +285,34 @@ jobs:
       # rather than plain nixpkgs#<attr>, so this is the exact same
       # derivation (overlays, unfree allowance, system) build-x86_64 would
       # otherwise build - not a look-alike from a different pkgs instantiation.
+      # Under `cachix watch-exec`: a Nix post-build hook uploads each path the
+      # moment it is built, so a leg that fails or is killed by the timeout
+      # still leaves everything it completed in the cache. Successive runs then
+      # start further along the dependency chain instead of from the same
+      # place. The end-of-step push below stays as a backstop.
       - name: Pre-warm ${{ matrix.attr }}
         id: prewarm
         continue-on-error: true
+        timeout-minutes: 110
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
-          nix build .#nixosConfigurations.nixos-desktop.pkgs.${{ matrix.attr }} --no-link --print-out-paths --keep-going > out.txt
+          # Probe first: `cachix watch-exec` failing would be indistinguishable
+          # from the build failing, and a cachix problem must never be reported
+          # as a broken config. If the subcommand isn't usable, build plainly -
+          # the end-of-job push still populates the cache either way.
+          WATCH=0
+          if [ "${{ steps.cachix_setup.outcome }}" = "success" ] && [ -n "$CACHIX_AUTH_TOKEN" ] \
+             && cachix watch-exec --help > /dev/null 2>&1; then
+            WATCH=1
+          fi
+          BUILD='nix build .#nixosConfigurations.nixos-desktop.pkgs.${{ matrix.attr }} --no-link --print-out-paths --keep-going > out.txt'
+          if [ "$WATCH" = 1 ]; then
+            echo "Building under 'cachix watch-exec' - paths are pushed as they are built."
+            cachix watch-exec ${{ env.CACHIX_NAME }} -- bash -c "$BUILD"
+          else
+            bash -c "$BUILD"
+          fi
 
       - name: Push ${{ matrix.attr }} to Cachix
         if: (success() || failure()) && steps.cachix_setup.outcome == 'success'
@@ -292,6 +359,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install CA Certificates
+        continue-on-error: true
         run: |
           # Best-effort freshness refresh: ca-certificates is preinstalled on
           # the runner image and Nix uses its own CA bundle (NIX_SSL_CERT_FILE),
@@ -303,12 +371,15 @@ jobs:
           sudo apt-get install -y ca-certificates || true
 
       - name: Set up QEMU
+        continue-on-error: true
         uses: docker/setup-qemu-action@v3
 
       - name: Open permissions on /mnt
+        continue-on-error: true
         run: sudo chmod 1777 /mnt
 
       - name: Add Swap
+        continue-on-error: true
         run: |
           # GitHub-hosted runners ship with an active swap file, so fallocate
           # on /swapfile fails with "Text file busy" (ETXTBSY). Disable and
@@ -323,6 +394,7 @@ jobs:
           free -h
 
       - name: Maximize Nix Space
+        continue-on-error: true
         uses: wimpysworld/nothing-but-nix@main
         with:
           hatchet-protocol: "cleave"
@@ -393,18 +465,46 @@ jobs:
           nix profile install --accept-flake-config nixpkgs#cachix
           cachix use ${{ env.CACHIX_NAME }}
 
+      # Wrapped in `cachix watch-exec`, which registers a Nix post-build hook
+      # and uploads each store path the moment it is built, in parallel with
+      # the rest of the build. That is what keeps a run that never reaches the
+      # push step from losing everything: hitting this step's timeout, the
+      # 350-minute job cap, or a cancellation no longer discards hours of work,
+      # because each path was already in the cache when it finished. It also
+      # lets successive runs make incremental progress through a long chain.
+      #
+      # Nix does not fire the hook for substituted paths, so only what was
+      # genuinely built here is uploaded. The push step below stays as a
+      # backstop for anything the hook missed.
+      #
+      # --keep-going: when a derivation fails (broken dep, unfree, or a package
+      # unsupported on this platform) keep building every other branch of the
+      # graph, so one bad package doesn't cost us the whole closure.
       - name: Build x86_64 Configurations
         id: build
-        # --keep-going: when a derivation fails (broken dep, unfree, or a
-        # package unsupported on this platform) keep building every other
-        # branch of the graph, so one bad package doesn't cost us the whole
-        # closure. The push step below runs regardless of this step's outcome
-        # and uploads whatever did build - so a partial failure still fails
-        # the job (the red check is the signal that something needs fixing)
-        # without throwing the build away.
         timeout-minutes: 270
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
-          nix build .#nixosConfigurations.nixos-desktop.config.system.build.toplevel --no-link --print-out-paths --keep-going --max-jobs 2 --cores 4 > outpaths.txt
+          # Redirect inside the inner shell so outpaths.txt gets Nix's stdout
+          # only, never watch-exec's own progress output.
+          # Probe first: `cachix watch-exec` failing would be indistinguishable
+          # from the build failing, and a cachix problem must never be reported
+          # as a broken config. If the subcommand isn't usable, build plainly -
+          # the end-of-job push still populates the cache either way.
+          WATCH=0
+          if [ "${{ steps.cachix_setup.outcome }}" = "success" ] && [ -n "$CACHIX_AUTH_TOKEN" ] \
+             && cachix watch-exec --help > /dev/null 2>&1; then
+            WATCH=1
+          fi
+          BUILD='nix build .#nixosConfigurations.nixos-desktop.config.system.build.toplevel --no-link --print-out-paths --keep-going --max-jobs 2 --cores 4 > outpaths.txt'
+          if [ "$WATCH" = 1 ]; then
+            echo "Building under 'cachix watch-exec' - paths are pushed as they are built."
+            cachix watch-exec ${{ env.CACHIX_NAME }} -- bash -c "$BUILD"
+          else
+            echo "Cachix unavailable - building without continuous push."
+            bash -c "$BUILD"
+          fi
 
       # Pushing to the binary cache is a non-critical secondary goal: it must
       # never fail the job on its own (e.g. the 2026-07-08 "Error: not found:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
       # rebuilding. Never fails the job: it is a cache optimisation.
       - name: Push Flake Check Output to Cachix
         id: cachix_push
-        if: (success() || failure()) && steps.cachix_setup.outcome == 'success'
+        if: always() && steps.cachix_setup.outcome == 'success'
         continue-on-error: true
         env:
           CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -292,8 +292,10 @@ jobs:
       # place. The end-of-step push below stays as a backstop.
       - name: Pre-warm ${{ matrix.attr }}
         id: prewarm
+        # 100 not 110: leaves a ~20-minute tail inside the 120-minute job
+        # cap for the backstop push.
         continue-on-error: true
-        timeout-minutes: 110
+        timeout-minutes: 100
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
@@ -315,7 +317,7 @@ jobs:
           fi
 
       - name: Push ${{ matrix.attr }} to Cachix
-        if: (success() || failure()) && steps.cachix_setup.outcome == 'success'
+        if: always() && steps.cachix_setup.outcome == 'success'
         continue-on-error: true
         env:
           CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -510,15 +512,22 @@ jobs:
       # never fail the job on its own (e.g. the 2026-07-08 "Error: not found:
       # cachix" incident).
       #
-      # (success() || failure()) rather than a plain success gate: salvaging a
-      # broken run is the whole point. If the build or the flake check failed,
-      # everything that DID build is still valid in the local store and still
-      # worth caching - dropping it makes the next run rebuild it from
-      # scratch. Deliberately NOT always(): a cancelled run (concurrency,
-      # manual) is killed mid-build and its store is not worth uploading.
+      # always(), not a success/failure gate: salvaging a broken run is the
+      # whole point. Whatever DID build is still valid in the local store and
+      # still worth caching - dropping it makes the next run rebuild it from
+      # scratch.
+      #
+      # Cancellation is included deliberately. cancel-in-progress fires often
+      # here (5 of 12 recent build.yml runs, 2 of 12 darwin runs), and run 1095
+      # shows always() steps really do execute in the grace window before the
+      # runner shuts down - it got roughly eleven minutes. That is the one
+      # difference from Save Nix Store Cache below, which stays off cancelled
+      # runs on purpose: a store snapshot taken mid-build is internally
+      # inconsistent, whereas Cachix uploads whole valid paths one at a time,
+      # so a push cut short just means fewer paths, never a corrupt cache.
       - name: Push to Cachix (x86_64)
         id: cachix_push
-        if: (success() || failure()) && steps.cachix_setup.outcome == 'success'
+        if: always() && steps.cachix_setup.outcome == 'success'
         continue-on-error: true
         env:
           CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -550,27 +559,10 @@ jobs:
           echo "No toplevel output path - pushing every valid store path instead."
           nix path-info --all | grep -v '\.drv$' | cachix push ${{ env.CACHIX_NAME }}
 
-      - name: Check Disk Usage
-        if: always()
-        continue-on-error: true
-        run: |
-          echo "--- Disk Space Usage ---"
-          df -h /nix
-          echo "--- Nix Store Size ---"
-          du -sh /nix/store
-          echo "--- Swap ---"
-          free -h
-
-      - name: Show Package Tree (x86_64)
-        if: always()
-        continue-on-error: true
-        run: |
-          if [ -s outpaths.txt ]; then
-            nix path-info -sh -r $(cat outpaths.txt)
-          else
-            echo "No output paths were built."
-          fi
-
+      # Ordered directly after the Cachix push and before the diagnostic
+      # steps: these two are the only things in the job that persist
+      # anything, so nothing that merely prints information may run
+      # ahead of them and eat a timeout or cancellation grace window.
       # Runs even when the build step failed or timed out, so partially built
       # derivations survive into the next attempt instead of rebuilding from
       # scratch every retry. NOT always(): a cancelled run (concurrency,
@@ -594,6 +586,30 @@ jobs:
           # deleted every good cache on each save, leaving only this run's
           # (possibly broken) one. GitHub's 10 GB per-repo LRU eviction
           # handles cleanup on its own.
+
+      # No `du -sh /nix/store` here: it walks the whole store and took over
+      # ten minutes on a 32G store in run 1095, where it burned the entire
+      # cancellation grace window and was SIGTERM'd (exit 143) before the
+      # steps that actually persist anything could run. df reports the same
+      # actionable number instantly.
+      - name: Check Disk Usage
+        if: always()
+        continue-on-error: true
+        run: |
+          echo "--- Disk Space Usage ---"
+          df -h /nix
+          echo "--- Swap ---"
+          free -h
+
+      - name: Show Package Tree (x86_64)
+        if: always()
+        continue-on-error: true
+        run: |
+          if [ -s outpaths.txt ]; then
+            nix path-info -sh -r $(cat outpaths.txt)
+          else
+            echo "No output paths were built."
+          fi
 
       - name: Notify on Failure (x86_64)
         if: failure() && env.WEBHOOK_ID != ''

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,14 +248,28 @@ jobs:
           nix build .#nixosConfigurations.nixos-desktop.pkgs.${{ matrix.attr }} --no-link --print-out-paths --keep-going > out.txt
 
       - name: Push ${{ matrix.attr }} to Cachix
-        if: steps.cachix_setup.outcome == 'success'
+        if: (success() || failure()) && steps.cachix_setup.outcome == 'success'
         continue-on-error: true
         env:
           CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
-          if [ -s out.txt ] && [ -n "$CACHIX_TOKEN" ]; then
-            cachix push ${{ env.CACHIX_NAME }} $(cat out.txt)
+          if [ -z "$CACHIX_TOKEN" ]; then
+            echo "Skipping Cachix push: no auth token found (likely a fork)."
+            exit 0
           fi
+
+          if [ -s out.txt ]; then
+            cachix push ${{ env.CACHIX_NAME }} $(cat out.txt)
+            exit 0
+          fi
+
+          # ${{ matrix.attr }} itself didn't finish, so there is no output
+          # path - but its dependencies that DID build are the expensive part
+          # and are exactly what this leg exists to warm. Push them rather
+          # than discarding the whole leg. Upstream-cache filtering keeps this
+          # to what actually got built here.
+          echo "No output path for ${{ matrix.attr }} - pushing every valid store path instead."
+          nix path-info --all | grep -v '\.drv$' | cachix push ${{ env.CACHIX_NAME }}
 
   build-x86_64:
     needs: prewarm-cache
@@ -381,37 +395,60 @@ jobs:
 
       - name: Build x86_64 Configurations
         id: build
-        # continue-on-error: --keep-going already builds everything it can
-        # even when some derivations fail (unfree/unsupported/broken deps),
-        # so a partial failure here must not skip the Cachix push below -
-        # we want to push whatever DID build, not push nothing. Genuine
-        # partial-failure visibility is handled by the dedicated notify step
-        # further down instead of by failing the job.
-        continue-on-error: true
+        # --keep-going: when a derivation fails (broken dep, unfree, or a
+        # package unsupported on this platform) keep building every other
+        # branch of the graph, so one bad package doesn't cost us the whole
+        # closure. The push step below runs regardless of this step's outcome
+        # and uploads whatever did build - so a partial failure still fails
+        # the job (the red check is the signal that something needs fixing)
+        # without throwing the build away.
         timeout-minutes: 270
         run: |
           nix build .#nixosConfigurations.nixos-desktop.config.system.build.toplevel --no-link --print-out-paths --keep-going --max-jobs 2 --cores 4 > outpaths.txt
 
-      # Non-critical secondary goal: pushing to the binary cache must never
-      # fail the job on its own (e.g. the 2026-07-08 "Error: not found:
-      # cachix" incident). Gated only on Cachix being set up, not on a clean
-      # build - outpaths.txt can hold partial results from a --keep-going
-      # run that hit some failures, and those are still worth caching.
+      # Pushing to the binary cache is a non-critical secondary goal: it must
+      # never fail the job on its own (e.g. the 2026-07-08 "Error: not found:
+      # cachix" incident).
+      #
+      # (success() || failure()) rather than a plain success gate: salvaging a
+      # broken run is the whole point. If the build or the flake check failed,
+      # everything that DID build is still valid in the local store and still
+      # worth caching - dropping it makes the next run rebuild it from
+      # scratch. Deliberately NOT always(): a cancelled run (concurrency,
+      # manual) is killed mid-build and its store is not worth uploading.
       - name: Push to Cachix (x86_64)
         id: cachix_push
-        if: steps.cachix_setup.outcome == 'success'
+        if: (success() || failure()) && steps.cachix_setup.outcome == 'success'
         continue-on-error: true
         env:
           CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
-          if [ ! -s outpaths.txt ]; then
-            echo "Skipping Cachix push: no output paths were built."
-          elif [ -n "$CACHIX_TOKEN" ]; then
-            cachix push ${{ env.CACHIX_NAME }} $(cat outpaths.txt)
-          else
-            echo "Skipping Cachix push: No auth token found (likely a fork)."
+          if [ -z "$CACHIX_TOKEN" ]; then
+            echo "Skipping Cachix push: no auth token found (likely a fork)."
+            exit 0
           fi
+
+          if [ -s outpaths.txt ]; then
+            # Clean build: push the toplevel closure. Fast and targeted.
+            cachix push ${{ env.CACHIX_NAME }} $(cat outpaths.txt)
+            exit 0
+          fi
+
+          # outpaths.txt is empty. --print-out-paths only prints paths Nix
+          # actually realised, and the toplevel system depends on everything,
+          # so ANY failed derivation leaves the toplevel unrealised and the
+          # file empty - even when --keep-going built thousands of paths
+          # first. Same when evaluation died before the build ran at all.
+          # Skipping the push here is exactly what used to throw away every
+          # partial result and make the next run start cold.
+          #
+          # Pushing the store wholesale is safe: Cachix's upstream-cache
+          # filter (on by default) drops every path already present in
+          # cache.nixos.org, so this uploads only what this repo actually
+          # produced, not a copy of nixpkgs.
+          echo "No toplevel output path - pushing every valid store path instead."
+          nix path-info --all | grep -v '\.drv$' | cachix push ${{ env.CACHIX_NAME }}
 
       - name: Check Disk Usage
         if: always()
@@ -425,6 +462,7 @@ jobs:
           free -h
 
       - name: Show Package Tree (x86_64)
+        if: always()
         continue-on-error: true
         run: |
           if [ -s outpaths.txt ]; then
@@ -463,21 +501,7 @@ jobs:
         env:
           WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
         run: |
-          jq -n --arg content "🚨 NixOS build failed on **x86_64**! Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
-          curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
-
-      # The build step is now continue-on-error (see its comment), so a
-      # partial --keep-going failure no longer fails the job/triggers the
-      # hard-failure notice above. Surface it here instead so broken
-      # derivations don't go silently unnoticed just because the rest of
-      # the closure built and pushed fine.
-      - name: Notify on Partial Build Failure (x86_64)
-        if: steps.build.outcome == 'failure' && env.WEBHOOK_ID != ''
-        continue-on-error: true
-        env:
-          WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-        run: |
-          jq -n --arg content "⚠️ NixOS build had errors on **x86_64** (some derivations failed) - pushed what succeeded to Cachix. Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
+          jq -n --arg content "🚨 NixOS build failed on **x86_64** (whatever did build was still pushed to Cachix). Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
           curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
 
       # Non-critical infra (store cache restore/save, cachix setup/push)


### PR DESCRIPTION
Reorders both workflows around one priority: **push as much working output to Cachix as possible**, with the flake check and notifications secondary. Applied symmetrically — the NixOS side turned out to have the worse failure mode.

## Evidence

| Run | What happened |
|---|---|
| [754](https://github.com/nicolkrit999/nix/actions/runs/31979248235) (darwin) | Ran **exactly 300m13s**, hit the step timeout, killed, push **skipped**. Disk was **100% full — 1.4 GiB left** — and the step emitted nothing at all for five hours. |
| [1095](https://github.com/nicolkrit999/nix/actions/runs/32044920476) (x86_64) | **Cancelled** with 78 GB free. `du -sh /nix/store` then walked a 32 GB store for **>10 min**, ate the whole grace window, SIGTERM'd (exit 143). Nothing persisted. |
| [762](https://github.com/nicolkrit999/nix/actions/runs/32069602724) (darwin) | Eval error (`libcap`, wrong `meta.platforms`). `outpaths.txt` empty → push skipped. |
| [764](https://github.com/nicolkrit999/nix/actions/runs/32166883895) (darwin) | Clean run, 8m35s, zero local builds, 29 GiB free — `Nothing to push - all store paths are already on Cachix`. |

5 of the last 12 `build.yml` runs and 2 of 12 `build-darwin` runs ended **cancelled** by `cancel-in-progress`, each discarding everything it had built.

## 1. Nothing pushed when anything failed

`--print-out-paths` only emits paths Nix actually realised. The toplevel depends on everything, so *any* failed derivation leaves it unrealised and `outpaths.txt` empty — even after `--keep-going` built thousands of paths. The push logged `no output paths were built` and uploaded nothing.

Push now falls back to `nix path-info --all | grep -v '\.drv$' | cachix push`. Safe wholesale: Cachix's [upstream-cache filter](https://blog.cachix.org/posts/2020-07-28-upstream-caches-avoiding-pushing-paths-in-cache-nixos-org/) drops everything already in `cache.nixos.org`.

## 2. The push only happened at the end

Every build and pre-warm step now runs under **`cachix watch-exec`**, which registers a Nix post-build hook and uploads each path *as it is built*. Run 754 built for five hours and cached none of it; run 1095's runner death is only survivable this way, since no end-of-job step can run once the runner is gone.

It also gives **incremental progress**: each run substitutes what earlier runs pushed and builds further along the chain instead of restarting.

`watch-exec` is probed before use, so a missing or unusable subcommand falls back to a plain build rather than reporting a cachix problem as a broken config. The end-of-job push stays as a backstop. Nix doesn't fire the hook for substituted paths, so only locally built paths upload.

## 3. Cancelled runs threw everything away

Every Cachix push now runs on `always()`. Run 1095 proves `always()` steps do execute in the grace window before shutdown — it got ~11 minutes.

`Save Nix Store Cache` deliberately keeps its narrower gate: a store snapshot taken mid-build is internally inconsistent (the 2026-07-07 `user-environment.drv does not exist` incident), whereas Cachix uploads whole valid paths one at a time, so a push cut short means fewer paths, never a corrupt cache.

## 4. Diagnostics starved the push

`du -sh /nix/store` is gone from both workflows — `df` gives the same actionable number instantly. In `build-x86_64`, `Save Nix Store Cache` also moves ahead of both diagnostic steps: the push and the cache save are the only things that persist anything, so nothing that merely prints information may run ahead of them.

## 5. The flake check could block the push

`nix flake check --all-systems` validates *every* output — all hosts, `homeConfigurations`, the formatter — so it fails for reasons unrelated to the host being built. Run 762 shows the converse too: the check **passed** and the build then failed. On Darwin it sits in the same job before the build, so a failure skipped the build and push entirely.

Now `continue-on-error`, with a **status gate after the push** re-asserting its outcome — still a red check and a Discord notice, just after the cache is populated.

The `flake-check` job also gained a push step. It realises real derivations (IFD, closure roots) and cached **none** of them, on success or failure.

## 6. Non-critical steps could kill the run

QEMU, swap, `/mnt` permissions, `nothing-but-nix`, CA certs — all `continue-on-error` now. What can still fail a job, and nothing else:

| Job | Hard-failing steps |
|---|---|
| `flake-check` | checkout, Install Nix, Verify Restored Store, status gate |
| `prewarm-cache` | checkout, Install Nix |
| `build-x86_64` | checkout, Install Nix, Verify Restored Store, the build |
| `build-darwin` | checkout, Install Nix, the build, status gate |

## 7. Disk exhaustion on cold darwin builds

Run 754's real cause. macOS runners share one APFS container and start with roughly 40 GiB free; that run reached 38 GiB of store with 1.4 GiB left and then went silent until the timeout. `min-free = 5 GB` / `max-free = 15 GB` now make Nix collect unreferenced paths when space runs low instead of wedging on a full disk.

Deliberately **darwin-only**. `build.yml` sets `keep-outputs`/`keep-derivations` on purpose so a saved store cache can never reference pruned files, and auto-GC would work against that — while having nothing to fix, since `nothing-but-nix` leaves that job ~78 GiB free. Darwin has no store cache to protect, and anything GC removes there has already been uploaded by `watch-exec`.

`prewarm-cache` step timeout drops 110 → 100 so the backstop push has a tail inside the 120-minute job cap.

## Verification

- All five workflow files parse as valid YAML.
- The build step's shell was extracted from the real YAML and run under `bash -e` against mock `nix`/`cachix` across six states: cachix healthy, build fails, cachix too old for `watch-exec`, cachix setup failed, fork with no token, cachix binary absent. All correct — and `cachix` writing noise to stdout does **not** contaminate `outpaths.txt`, confirming the inner-shell redirect.
- The push step was exercised for: clean build, empty `outpaths.txt`, absent `outpaths.txt`, no auth token.
- No `.nix` files touched.

## Corrected mid-review

An earlier commit added a `prewarm-darwin` job on the theory that Thunderbird isn't published for `aarch64-darwin`. That was wrong: run 764 substitutes `thunderbird-unwrapped-153.0.2` straight from `cache.nixos.org`. Run 754 was building **153.0.1**, in a window where nixpkgs had bumped but Hydra hadn't published the darwin build yet — and it died of disk exhaustion, not of one slow package. The job is removed (it reserved a second macOS runner for something that normally substitutes, and splitting wouldn't reduce peak disk in the job that still materialises the whole closure), and replaced by the auto-GC above.

## Deliberately not done

**No store cache for Darwin.** GitHub's cache is 10 GB per repo and the Linux store already claims 7 GB of it; a second would evict the first. With `watch-exec`, Cachix covers cross-run persistence for both platforms.