### PR TITLE
ci: stop the fallback push uploading per-run installer junk

### DIFF
--- a/.github/workflows/build-darwin.yml
+++ b/.github/workflows/build-darwin.yml
@@ -193,7 +193,14 @@ jobs:
           # cache.nixos.org, so this uploads only what this repo actually
           # produced, not a copy of nixpkgs.
           echo "No toplevel output path - pushing every valid store path instead."
-          nix path-info --all | grep -v '\.drv$' | cachix push ${{ env.CACHIX_NAME }}
+          # -self-test-: the Determinate installer writes a self-test path per
+          # run whose name carries a timestamp (self-test-bash-1787097653189,
+          # self-test-zsh-...), so it is a brand-new store path every single
+          # run. Observed being pushed on both platforms; left in, it grows the
+          # cache without bound for no benefit, since nothing ever substitutes
+          # it. Everything else the installer produces is version-stable and
+          # deduplicates, so a narrow exclusion is enough.
+          nix path-info --all | grep -v -e '\.drv$' -e '-self-test-' | cachix push ${{ env.CACHIX_NAME }}
 
       # No `du -sh /nix/store` here - see the matching step in build.yml.
       # It cost 2m49s on run 754 and over ten minutes on a large Linux store,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,14 @@ jobs:
           # No single output path to name here - flake check has many roots -
           # so push the store. Upstream-cache filtering keeps this to what this
           # run actually produced rather than a copy of nixpkgs.
-          nix path-info --all | grep -v '\.drv$' | cachix push ${{ env.CACHIX_NAME }}
+          # -self-test-: the Determinate installer writes a self-test path per
+          # run whose name carries a timestamp (self-test-bash-1787097653189,
+          # self-test-zsh-...), so it is a brand-new store path every single
+          # run. Observed being pushed on both platforms; left in, it grows the
+          # cache without bound for no benefit, since nothing ever substitutes
+          # it. Everything else the installer produces is version-stable and
+          # deduplicates, so a narrow exclusion is enough.
+          nix path-info --all | grep -v -e '\.drv$' -e '-self-test-' | cachix push ${{ env.CACHIX_NAME }}
 
       - name: Check for Dead Code (deadnix)
         continue-on-error: true
@@ -338,7 +345,14 @@ jobs:
           # than discarding the whole leg. Upstream-cache filtering keeps this
           # to what actually got built here.
           echo "No output path for ${{ matrix.attr }} - pushing every valid store path instead."
-          nix path-info --all | grep -v '\.drv$' | cachix push ${{ env.CACHIX_NAME }}
+          # -self-test-: the Determinate installer writes a self-test path per
+          # run whose name carries a timestamp (self-test-bash-1787097653189,
+          # self-test-zsh-...), so it is a brand-new store path every single
+          # run. Observed being pushed on both platforms; left in, it grows the
+          # cache without bound for no benefit, since nothing ever substitutes
+          # it. Everything else the installer produces is version-stable and
+          # deduplicates, so a narrow exclusion is enough.
+          nix path-info --all | grep -v -e '\.drv$' -e '-self-test-' | cachix push ${{ env.CACHIX_NAME }}
 
   build-x86_64:
     needs: prewarm-cache
@@ -557,7 +571,14 @@ jobs:
           # cache.nixos.org, so this uploads only what this repo actually
           # produced, not a copy of nixpkgs.
           echo "No toplevel output path - pushing every valid store path instead."
-          nix path-info --all | grep -v '\.drv$' | cachix push ${{ env.CACHIX_NAME }}
+          # -self-test-: the Determinate installer writes a self-test path per
+          # run whose name carries a timestamp (self-test-bash-1787097653189,
+          # self-test-zsh-...), so it is a brand-new store path every single
+          # run. Observed being pushed on both platforms; left in, it grows the
+          # cache without bound for no benefit, since nothing ever substitutes
+          # it. Everything else the installer produces is version-stable and
+          # deduplicates, so a narrow exclusion is enough.
+          nix path-info --all | grep -v -e '\.drv$' -e '-self-test-' | cachix push ${{ env.CACHIX_NAME }}
 
       # Ordered directly after the Cachix push and before the diagnostic
       # steps: these two are the only things in the job that persist


### PR DESCRIPTION
Follow-up to #40, from a defect its own CI logs exposed.

## The problem

The whole-store fallback push added in #40 uploads everything valid in the store, relying on Cachix's upstream-cache filter to drop whatever is already in `cache.nixos.org`. That filter can't help for paths the Determinate installer builds locally — and one of those is per-run garbage:

```
Pushing /nix/store/y8wpq...-self-test-bash-1787097653189 (120.00 B)
Pushing /nix/store/w4i7g...-self-test-zsh-1787096527164  (120.00 B)
```

Observed on **both** platforms: darwin [run 767](https://github.com/nicolkrit999/nix/actions/runs/32198131233) and the `flake-check` job of [run 1107](https://github.com/nicolkrit999/nix/actions/runs/32198462503).

The name carries a timestamp, so every run mints a brand-new store path that nothing will ever substitute. Unbounded cache growth for zero benefit.

## The fix

Excluded by name in all four fallback pushes — `flake-check`, `prewarm-cache` and `build-x86_64` in `build.yml`, plus `build-darwin` in `build-darwin.yml`:

```diff
-nix path-info --all | grep -v '\.drv$' | cachix push $CACHIX_NAME
+nix path-info --all | grep -v -e '\.drv$' -e '-self-test-' | cachix push $CACHIX_NAME
```

Kept deliberately narrow. The installer's other outputs (`determinate-nix-3.21.9` and friends) are version-stable, so they deduplicate across runs and are worth having in the cache.

## Verification

Re-ran the same `bash -e` mock harness used for #40, seeded with the exact paths from those two logs:

| Path | Result |
|---|---|
| `self-test-bash-1787097653189` | dropped ✅ |
| `self-test-zsh-1787096527164` | dropped ✅ |
| `ccc-thing.drv` | dropped ✅ |
| `darwin-system-26.05` | kept ✅ |
| `home-manager-generation` | kept ✅ |
| `determinate-nix-3.21.9` | kept ✅ |
| `build-doom-profile.sh` | kept ✅ |

The clean-build path — which pushes the toplevel closure by name rather than going through the fallback — is untouched and was re-checked.

No `.nix` files touched, so flake evaluation is unaffected. Both workflows parse as valid YAML.

## Scope note

This only affects the **fallback** push, which runs when there's no toplevel output path — a failed, partial, timed-out or cancelled build. A clean run pushes the toplevel closure by name and never had this problem.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeyWXPgCudXoKEit4LLDkS)_