### PR TITLE
ci: make the Cachix push survive failure, cancellation and a dead runner

### DIFF
--- a/.github/scripts/check-workflow-invariants.py
+++ b/.github/scripts/check-workflow-invariants.py
@@ -181,6 +181,17 @@ def check_workflow(path):
                              f"matrix variable. All legs of a run share run_id/run_attempt, so "
                              f"the keys collide.")
 
+            # 11. Every curl to a Discord webhook must use --fail. Without it curl
+            #     exits 0 on an HTTP 4xx/5xx, so a rotated or revoked webhook token
+            #     reports a delivered notification that never arrived.
+            if "WEBHOOK_URL" in run and "curl" in run:
+                checked += 1
+                if not re.search(r"curl[^\n]*--fail", run):
+                    fail(wf, job_name, name, "webhook-curl-fail",
+                         "curls the Discord webhook without --fail. curl exits 0 on HTTP "
+                         "4xx/5xx, so a rotated or revoked token is reported as a delivered "
+                         "notification that in fact never arrived.")
+
             # 10. A notifier that can fire without a webhook configured spams
             #     errors; one that is not continue-on-error can fail the job for a
             #     Discord outage.
@@ -197,6 +208,42 @@ def check_workflow(path):
                          "fork with no secrets this curls a malformed URL every run.")
 
 
+def check_cache_keys(path):
+    """12. A restore prefix that matches no save key means the job silently always
+    runs cold. Introduced for real by reordering a matrix variable into the middle
+    of the save key while a sibling job still restored the old prefix - nothing
+    errors, the cache simply never hits again.
+    """
+    global checked
+    wf = path.name
+    doc = yaml.safe_load(path.read_text())
+    if not doc or "jobs" not in doc:
+        return
+
+    save_keys = []
+    for job in doc["jobs"].values():
+        for st in job.get("steps") or []:
+            if st.get("uses", "").startswith("nix-community/cache-nix-action/save"):
+                k = str((st.get("with") or {}).get("primary-key", ""))
+                if k:
+                    save_keys.append(k)
+    if not save_keys:
+        return
+
+    for job_name, job in doc["jobs"].items():
+        for i, st in enumerate(job.get("steps") or []):
+            if not st.get("uses", "").startswith("nix-community/cache-nix-action/restore"):
+                continue
+            prefixes = str((st.get("with") or {}).get("restore-prefixes-first-match", ""))
+            for pref in [p.strip() for p in prefixes.splitlines() if p.strip()]:
+                checked += 1
+                if not any(k.startswith(pref) for k in save_keys):
+                    fail(wf, job_name, step_name(st, i), "cache-prefix-match",
+                         f"restore prefix '{pref}' is not a prefix of ANY save key in this "
+                         f"workflow, so it can never hit. The job will silently run cold "
+                         f"forever. Save keys: {save_keys}")
+
+
 def main():
     paths = sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml"))
     if not paths:
@@ -204,6 +251,7 @@ def main():
 
     for p in paths:
         check_workflow(p)
+        check_cache_keys(p)
 
     print(f"checked {checked} invariant(s) across {len(paths)} workflow file(s)\n")
     if failures:

--- a/.github/scripts/check-workflow-invariants.py
+++ b/.github/scripts/check-workflow-invariants.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Repo-specific invariants for the CI workflows.
+
+Every check here encodes a bug that actually happened in this repository, with
+the run number that exposed it. This is deliberately NOT a general-purpose
+linter - actionlint already covers generic Actions mistakes. What it protects is
+the one property those generic tools cannot know about:
+
+    whatever CI manages to build MUST end up in the Cachix cache, and a failure
+    to do so must never be silent.
+
+Run:  python3 .github/scripts/check-workflow-invariants.py
+Exit: 0 = clean, 1 = at least one invariant violated.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML is required: pip install pyyaml")
+
+WORKFLOW_DIR = Path(__file__).resolve().parents[1] / "workflows"
+
+# Workflows whose whole reason to exist is populating the binary cache. The
+# push-specific invariants apply only to these; tests-*.yml and update-flake.yml
+# are not cache producers.
+CACHE_PRODUCERS = {"build.yml", "build-darwin.yml"}
+
+failures = []
+checked = 0
+
+
+def fail(wf, job, step, check, msg):
+    where = f"{wf} :: {job}"
+    if step:
+        where += f" :: {step}"
+    failures.append(f"[{check}] {where}\n    {msg}")
+
+
+def effective_env(wf_doc, job, step):
+    """Env a step actually sees: workflow-level, then job, then step."""
+    env = {}
+    for src in (wf_doc.get("env") or {}, (job.get("env") or {}), (step.get("env") or {})):
+        env.update(src)
+    return env
+
+
+def step_name(step, idx):
+    return step.get("name") or step.get("uses") or f"step #{idx}"
+
+
+def check_workflow(path):
+    global checked
+    wf = path.name
+    doc = yaml.safe_load(path.read_text())
+    if not doc or "jobs" not in doc:
+        return
+
+    for job_name, job in doc["jobs"].items():
+        steps = job.get("steps") or []
+        declared_ids = {s["id"] for s in steps if "id" in s}
+        coe_ids = {
+            s["id"] for s in steps
+            if "id" in s and s.get("continue-on-error") is True
+        }
+
+        # Index of the first step that pushes to Cachix, for ordering checks.
+        push_idx = None
+        for i, s in enumerate(steps):
+            if re.search(r"\bcachix\s+push\b", s.get("run") or ""):
+                push_idx = i if push_idx is None else push_idx
+
+        for i, step in enumerate(steps):
+            name = step_name(step, i)
+            run = step.get("run") or ""
+            env = effective_env(doc, job, step)
+            cond = str(step.get("if", ""))
+
+            # 1. Anything invoking the cachix CLI to WRITE must have the variable
+            #    the CLI actually reads. Run 1111: the prewarm push step set only
+            #    CACHIX_TOKEN, cachix reads CACHIX_AUTH_TOKEN, so it failed with
+            #    "Neither auth token nor signing key are present." on every leg of
+            #    every run - and continue-on-error reported the step as SUCCESS.
+            if re.search(r"\bcachix\s+(push|watch-exec)\b", run):
+                checked += 1
+                if "CACHIX_AUTH_TOKEN" not in env:
+                    fail(wf, job_name, name, "cachix-auth",
+                         "invokes `cachix push`/`watch-exec` but CACHIX_AUTH_TOKEN is not in "
+                         "its effective env. cachix reads CACHIX_AUTH_TOKEN; a guard variable "
+                         "such as CACHIX_TOKEN does not authenticate anything. (run 1111)")
+
+            if wf in CACHE_PRODUCERS and re.search(r"\bcachix\s+push\b", run):
+                # 2. Salvaging a broken run is the entire point: the push must run
+                #    even when the build failed, timed out, or was cancelled.
+                checked += 1
+                if "always()" not in cond:
+                    fail(wf, job_name, name, "push-always",
+                         "pushes to Cachix but its `if:` does not use always(). Without a "
+                         "status function the step is SKIPPED once the job has failed, which "
+                         "is precisely when there is most to salvage.")
+
+                # 3. Pushing is a secondary goal and must never fail the job.
+                checked += 1
+                if step.get("continue-on-error") is not True:
+                    fail(wf, job_name, name, "push-non-fatal",
+                         "pushes to Cachix but is not continue-on-error: true. A Cachix "
+                         "outage must not turn a successful build into a failed job.")
+
+            # 4. A reference to a step id that does not exist in the SAME job
+            #    silently evaluates to the empty string - it does not error. That
+            #    is how a notifier condition came to test a step nothing declared.
+            for ref in re.findall(r"steps\.([A-Za-z0-9_-]+)\.", run + " " + cond):
+                checked += 1
+                if ref not in declared_ids:
+                    fail(wf, job_name, name, "step-ref",
+                         f"references steps.{ref}.* but no step with id '{ref}' is declared "
+                         f"in job '{job_name}'. Cross-job references evaluate to '' silently.")
+
+            # 5. On a continue-on-error step .conclusion is ALWAYS 'success'.
+            #    Testing it is dead code; .outcome carries the truth.
+            for ref in re.findall(r"steps\.([A-Za-z0-9_-]+)\.conclusion", run + " " + cond):
+                checked += 1
+                if ref in coe_ids:
+                    fail(wf, job_name, name, "outcome-not-conclusion",
+                         f"tests steps.{ref}.conclusion, but '{ref}' is continue-on-error, so "
+                         f"its conclusion is always 'success'. Use steps.{ref}.outcome.")
+
+            # 6. GitHub runs these with `bash -e`, NOT `-o pipefail`. A pipe into
+            #    tee or cachix therefore reports the LAST command's status and
+            #    masks the real failure - the silent-success shape again.
+            if run and re.search(r"\|\s*(tee|cachix)\b", run):
+                checked += 1
+                if "set -o pipefail" not in run and "set -eo pipefail" not in run:
+                    fail(wf, job_name, name, "pipefail",
+                         "pipes into tee/cachix without `set -o pipefail`. Under bash -e the "
+                         "pipeline's exit status is the last command's, so an upstream failure "
+                         "is masked and the step reports success having done nothing.")
+
+            # 7. A single-quoted variable holding a command that is later handed to
+            #    `bash -c` must not contain bare newlines: bash -c reads each line
+            #    as a separate command. Caught once before it shipped, in the
+            #    BUILD='nix build ...' variable.
+            if "bash -c" in run:
+                for var, body in re.findall(r"^\s*([A-Z_][A-Z0-9_]*)='([^']*)'", run, re.M):
+                    if f'"${var}"' in run or f"${var}" in run:
+                        checked += 1
+                        if "\n" in body:
+                            lines = [l.rstrip() for l in body.split("\n") if l.strip()]
+                            if any(not l.endswith("\\") for l in lines[:-1]):
+                                fail(wf, job_name, name, "bash-c-newline",
+                                     f"${var} spans multiple lines without backslash "
+                                     f"continuations and is passed to `bash -c`, which reads "
+                                     f"each line as its own command.")
+
+            # 8. Anything that walks the whole store before the push can eat the
+            #    entire cancellation grace window. Run 1095: `du -sh /nix/store`
+            #    took over ten minutes and was SIGTERM'd (exit 143) before the
+            #    push could run. df reports the actionable number instantly.
+            if push_idx is not None and i < push_idx:
+                checked += 1
+                if re.search(r"\bdu\s+-[a-z]*s[a-z]*\b.*/nix/store", run):
+                    fail(wf, job_name, name, "grace-window",
+                         "walks /nix/store with `du` BEFORE the Cachix push. On a cancelled "
+                         "run this consumes the grace window and the push never happens. "
+                         "Use `df -h /nix`. (run 1095)")
+
+            # 9. Matrix legs share github.run_id and github.run_attempt, so a cache
+            #    key that does not mention the matrix variable collides between
+            #    legs of the same run and one leg's store is lost.
+            if step.get("uses", "").startswith("nix-community/cache-nix-action"):
+                key = str((step.get("with") or {}).get("primary-key", ""))
+                matrix = (job.get("strategy") or {}).get("matrix") or {}
+                if matrix and key:
+                    checked += 1
+                    if not any(f"matrix.{k}" in key for k in matrix):
+                        fail(wf, job_name, name, "matrix-cache-key",
+                             f"job '{job_name}' is a matrix but its cache primary-key names no "
+                             f"matrix variable. All legs of a run share run_id/run_attempt, so "
+                             f"the keys collide.")
+
+            # 10. A notifier that can fire without a webhook configured spams
+            #     errors; one that is not continue-on-error can fail the job for a
+            #     Discord outage.
+            if "discord.com/api/webhooks" in str(step.get("env", {})) or "WEBHOOK_URL" in run:
+                checked += 1
+                if step.get("continue-on-error") is not True:
+                    fail(wf, job_name, name, "notify-non-fatal",
+                         "posts to Discord but is not continue-on-error: true. A webhook "
+                         "outage must not fail the job.")
+                checked += 1
+                if "WEBHOOK_ID" not in cond:
+                    fail(wf, job_name, name, "notify-guard",
+                         "posts to Discord without guarding on env.WEBHOOK_ID != ''. On a "
+                         "fork with no secrets this curls a malformed URL every run.")
+
+
+def main():
+    paths = sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml"))
+    if not paths:
+        sys.exit(f"no workflow files found under {WORKFLOW_DIR}")
+
+    for p in paths:
+        check_workflow(p)
+
+    print(f"checked {checked} invariant(s) across {len(paths)} workflow file(s)\n")
+    if failures:
+        print(f"{len(failures)} violation(s):\n")
+        for f in failures:
+            print(f + "\n")
+        return 1
+    print("all workflow invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/build-darwin.yml
+++ b/.github/workflows/build-darwin.yml
@@ -169,8 +169,14 @@ jobs:
           CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
+          # pipefail: the `| tee` below would otherwise mask cachix's exit code,
+          # reintroducing exactly the silent-success failure this step exists
+          # to avoid.
+          set -o pipefail
+
           if [ -z "$CACHIX_TOKEN" ]; then
             echo "Skipping Cachix push: no auth token found (likely a fork)."
+            echo "pushed=skipped" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -205,9 +211,17 @@ jobs:
           # first so that failure is visible.
           if ! nix path-info --all > allpaths.txt; then
             echo "::warning::nix path-info failed - nothing could be pushed this run."
+            echo "pushed=error" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          grep -v -e '\.drv$' -e '-self-test-' allpaths.txt | cachix push ${{ env.CACHIX_NAME }}
+          grep -v -e '\.drv$' -e '-self-test-' allpaths.txt > topush.txt || true
+          if [ ! -s topush.txt ]; then
+            echo "Nothing left to push after filtering."
+            echo "pushed=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          cachix push ${{ env.CACHIX_NAME }} < topush.txt 2>&1 | tee push.log
+          echo "pushed=$(grep -c '^Pushing ' push.log || true)" >> "$GITHUB_OUTPUT"
 
       # No `du -sh /nix/store` here - see the matching step in build.yml.
       # It cost 2m49s on run 754 and over ten minutes on a large Linux store,
@@ -244,31 +258,81 @@ jobs:
           fi
           echo "flake check: ${{ steps.flake_check.outcome }}, build: ${{ steps.build.outcome }}"
 
-      - name: Notify on Failure (Darwin)
-        if: failure() && env.WEBHOOK_ID != ''
+      # ONE consolidated notice per job, replacing the previous separate ones.
+      # The old split was structurally unsound: hard failures fired on
+      # failure() while infra problems fired on success(), so a FAILED job
+      # suppressed the infra report entirely - you would never learn that
+      # Cachix had broken too. It also let a condition name a step the message
+      # body never mentioned, which is how a notice could fire listing nothing.
+      # Collecting every finding in the same step that decides whether to send
+      # removes both classes of bug.
+      #
+      # Silent on a clean run: no findings, no message.
+      #
+      # Shell note: findings are appended inside `if` blocks, never as
+      # `[ test ] && append`. Under `bash -e` a false test makes that an `&&`
+      # list returning non-zero, which aborts the step - the notifier would
+      # stop at the first finding that did not apply.
+      - name: Notify (darwin)
+        if: always() && env.WEBHOOK_ID != ''
         continue-on-error: true
         env:
           WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          jq -n --arg content "🚨 nix-darwin run failed on **aarch64-darwin** (flake check and/or build - whatever did build was still pushed to Cachix). Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
+          CRIT=""; WARN=""; INFO=""; NOTE=""
+          crit() { CRIT="${CRIT}🔴 $1"$'\n'; }
+          warn() { WARN="${WARN}🟠 $1"$'\n'; }
+          info() { INFO="${INFO}🔵 $1"$'\n'; }
+          # note() rides along in a message that is being sent anyway, but never
+          # causes one on its own. Routine facts - "0 new paths, everything was
+          # already cached" - are true on every warm run, so promoting them to a
+          # trigger would mean a Discord message after every single green build,
+          # and a channel nobody reads is the same as no notifications at all.
+          note() { NOTE="${NOTE}⚪ $1"$'\n'; }
+          if [ "${{ steps.flake_check.outcome }}" = "failure" ]; then
+            crit "\`nix flake check --impure\` failed - the build and Cachix push still ran"
+          fi
+          if [ "${{ steps.build.outcome }}" = "failure" ]; then
+            crit "Build failed or timed out - whatever DID build was still pushed to Cachix"
+          fi
+          if [ "${{ steps.cachix_setup.outcome }}" = "failure" ]; then
+            warn "Cachix CLI setup failed - nothing could be pushed this run"
+          fi
+          if [ "${{ steps.cachix_push.outcome }}" = "failure" ]; then
+            warn "Cachix push failed - build output was not cached"
+          fi
+          P="${{ steps.cachix_push.outputs.pushed }}"
+          if [ "$P" = "error" ]; then
+            warn "\`nix path-info\` failed - the store could not be listed, so nothing was pushed"
+          elif [ "$P" = "0" ]; then
+            note "Cachix push uploaded 0 new paths"
+          elif [ -n "$P" ] && [ "$P" != "skipped" ]; then
+            note "Pushed $P new store path(s) to Cachix"
+          fi
+          # 0 pushed after a FAILED build is different from 0 after a clean one:
+          # --keep-going plus the whole-store fallback should have salvaged
+          # something, so nothing uploaded means the salvage path itself did not
+          # work. Worth waking someone for.
+          if [ "$P" = "0" ] && [ "${{ steps.build.outcome }}" = "failure" ]; then
+            warn "Build failed AND the fallback push uploaded nothing - partial results were NOT salvaged"
+          fi
+
+          # Send decision uses CRIT/WARN/INFO only; NOTE rides along.
+          BODY="${CRIT}${WARN}${INFO}${NOTE}"
+          if [ -z "${CRIT}${WARN}${INFO}" ]; then
+            echo "Nothing to report - no notification sent."
+            exit 0
+          fi
+          if [ -n "$CRIT" ]; then
+            HEAD="🚨 **build-darwin - failed**"
+          elif [ -n "$WARN" ]; then
+            HEAD="⚠️ **build-darwin - finished, but with problems**"
+          else
+            HEAD="ℹ️ **build-darwin**"
+          fi
+          jq -n --arg h "$HEAD" --arg b "$BODY" --arg u "$RUN_URL" \
+            '{content: ($h + "\n" + $b + "\n" + $u)}' > payload.json
           curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
 
-      # Non-critical infra (cachix setup/push) failing must not fail the
-      # job, but should still be surfaced - reported separately from the
-      # hard-failure notice above, which only fires when the actual build
-      # step failed.
-      - name: Notify Non-Critical Issues (Darwin)
-        if: success() && env.WEBHOOK_ID != '' && (steps.cachix_setup.outcome == 'failure' || steps.cachix_push.outcome == 'failure')
-        continue-on-error: true
-        env:
-          WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-        run: |
-          ISSUES=""
-          if [ "${{ steps.cachix_setup.outcome }}" == "failure" ]; then
-            ISSUES="${ISSUES}- Cachix CLI setup failed (binary cache push skipped this run)"$'\n'
-          fi
-          if [ "${{ steps.cachix_push.outcome }}" == "failure" ]; then
-            ISSUES="${ISSUES}- Cachix push failed (build succeeded, but its outputs weren't cached)"$'\n'
-          fi
-          jq -n --arg content "⚠️ build-darwin: non-critical CI infra issue(s), job still succeeded:"$'\n'"${ISSUES}Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
-          curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
+

--- a/.github/workflows/build-darwin.yml
+++ b/.github/workflows/build-darwin.yml
@@ -174,25 +174,23 @@ jobs:
             exit 0
           fi
 
-          if [ -s outpaths.txt ]; then
-            # Clean build: push the toplevel closure. Fast and targeted.
-            cachix push ${{ env.CACHIX_NAME }} $(cat outpaths.txt)
-            exit 0
-          fi
-
-          # outpaths.txt is empty. --print-out-paths only prints paths Nix
-          # actually realised, and the toplevel system depends on everything,
-          # so ANY failed derivation leaves the toplevel unrealised and the
-          # file empty - even when --keep-going built thousands of paths
-          # first. Same when evaluation died before the build ran at all.
-          # Skipping the push here is exactly what used to throw away every
-          # partial result and make the next run start cold.
+          # Always the whole store here, with no targeted fast path - unlike
+          # build.yml, where the flake check is a separate job that pushes its
+          # own store. On Darwin the flake check shares this job and runs
+          # OUTSIDE watch-exec, so anything it builds is covered by neither the
+          # post-build hook nor the toplevel closure; a targeted push would
+          # silently leave it uncached on every clean run.
           #
-          # Pushing the store wholesale is safe: Cachix's upstream-cache
-          # filter (on by default) drops every path already present in
-          # cache.nixos.org, so this uploads only what this repo actually
-          # produced, not a copy of nixpkgs.
-          echo "No toplevel output path - pushing every valid store path instead."
+          # It also covers the case that motivated the fallback in the first
+          # place: --print-out-paths only prints paths Nix actually realised,
+          # and the toplevel depends on everything, so ANY failed derivation
+          # leaves outpaths.txt empty even when --keep-going built thousands of
+          # paths first.
+          #
+          # Safe wholesale: Cachix's upstream-cache filter (on by default)
+          # drops every path already in cache.nixos.org, so this uploads only
+          # what this repo actually produced, not a copy of nixpkgs.
+          echo "Pushing every valid store path (build output plus anything the flake check built)."
           # -self-test-: the Determinate installer writes a self-test path per
           # run whose name carries a timestamp (self-test-bash-1787097653189,
           # self-test-zsh-...), so it is a brand-new store path every single
@@ -200,7 +198,16 @@ jobs:
           # cache without bound for no benefit, since nothing ever substitutes
           # it. Everything else the installer produces is version-stable and
           # deduplicates, so a narrow exclusion is enough.
-          nix path-info --all | grep -v -e '\.drv$' -e '-self-test-' | cachix push ${{ env.CACHIX_NAME }}
+          # Not a bare pipeline: GitHub runs these with `bash -e`, not
+          # `-o pipefail`, so a failing `nix path-info` would be masked - cachix
+          # would read empty stdin, report nothing to push and exit 0, and the
+          # run would look fine while caching nothing. Materialise the list
+          # first so that failure is visible.
+          if ! nix path-info --all > allpaths.txt; then
+            echo "::warning::nix path-info failed - nothing could be pushed this run."
+            exit 0
+          fi
+          grep -v -e '\.drv$' -e '-self-test-' allpaths.txt | cachix push ${{ env.CACHIX_NAME }}
 
       # No `du -sh /nix/store` here - see the matching step in build.yml.
       # It cost 2m49s on run 754 and over ten minutes on a large Linux store,

--- a/.github/workflows/build-darwin.yml
+++ b/.github/workflows/build-darwin.yml
@@ -42,6 +42,13 @@ jobs:
           flakehub: false
           extra-conf: |
             auto-optimise-store = true
+            # Same idea as build.yml: give CI the caches the machines already
+            # trust, so it substitutes instead of compiling. Only the two that
+            # actually apply to aarch64-darwin - hyprland/cosmic/walker/vicinae
+            # are Linux-only, and every extra substituter costs a narinfo
+            # round-trip per path.
+            extra-substituters = https://claude-code.cachix.org https://catppuccin.cachix.org
+            extra-trusted-public-keys = claude-code.cachix.org-1:YeXf2aNu7UTX8Vwrze0za1WEDS+4DuI2kVeWEE4fsRk= catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732n/9sI=
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             # Auto-GC during the build. macOS runners share one APFS container

--- a/.github/workflows/build-darwin.yml
+++ b/.github/workflows/build-darwin.yml
@@ -81,7 +81,15 @@ jobs:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
           nix profile install --accept-flake-config nixpkgs#cachix
-          cachix use ${{ env.CACHIX_NAME }}
+          # NOT fatal, and deliberately so. `cachix use` configures this cache as
+          # a SUBSTITUTER - it affects downloading and has nothing to do with
+          # pushing. Every push step in this workflow is gated on this step's
+          # outcome, so letting `cachix use` fail the step meant a transient
+          # substituter-config hiccup silently disabled ALL pushing even with a
+          # perfectly valid token. The gate now reflects what it claims to:
+          # whether the cachix CLI is installed and usable.
+          cachix use ${{ env.CACHIX_NAME }} \
+            || echo "::warning::cachix use failed - this cache is not configured as a substituter for this job. Pushing is unaffected."
 
       # continue-on-error: the flake check is this workflow's SECONDARY goal.
       # It validates every flake output - other hosts, homeConfigurations, the
@@ -340,6 +348,10 @@ jobs:
           fi
           jq -n --arg h "$HEAD" --arg b "$BODY" --arg u "$RUN_URL" \
             '{content: ($h + "\n" + $b + "\n" + $u)}' > payload.json
-          curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
+          # --fail so a rotated/revoked webhook is not reported as delivered, and
+          # `|| echo` so the notice never fails the step (and is never the last
+          # command left returning non-zero under bash -e).
+          curl -sS --fail -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL" \
+            || echo "::warning::Discord webhook delivery failed - the notification above was NOT sent."
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -496,6 +496,9 @@ jobs:
       # --keep-going: when a derivation fails (broken dep, unfree, or a package
       # unsupported on this platform) keep building every other branch of the
       # graph, so one bad package doesn't cost us the whole closure.
+      # Builds nixos-desktop AND nixos-laptop: a rebuild on either machine
+      # after a flake bump should substitute rather than build, including
+      # the host-specific paths that differ between them.
       - name: Build x86_64 Configurations
         id: build
         timeout-minutes: 270
@@ -513,7 +516,19 @@ jobs:
              && cachix watch-exec --help > /dev/null 2>&1; then
             WATCH=1
           fi
-          BUILD='nix build .#nixosConfigurations.nixos-desktop.config.system.build.toplevel --no-link --print-out-paths --keep-going --max-jobs 2 --cores 4 > outpaths.txt'
+          # Both x86_64 hosts in ONE nix build on ONE runner, not two jobs:
+          # they share nearly their whole closure, so the laptop's marginal
+          # cost is only its host-specific derivations (home-manager
+          # generation, system-path, activation scripts) rather than a second
+          # full build. --keep-going means a failure in one still builds the
+          # other, and --print-out-paths writes one line per realised toplevel,
+          # so outpaths.txt may legitimately hold one path or two.
+          # Backslash continuations, not bare newlines: BUILD is handed to
+          # `bash -c`, which would otherwise read each line as its own command.
+          BUILD='nix build \
+                   .#nixosConfigurations.nixos-desktop.config.system.build.toplevel \
+                   .#nixosConfigurations.nixos-laptop.config.system.build.toplevel \
+                   --no-link --print-out-paths --keep-going --max-jobs 2 --cores 4 > outpaths.txt'
           if [ "$WATCH" = 1 ]; then
             echo "Building under 'cachix watch-exec' - paths are pushed as they are built."
             cachix watch-exec ${{ env.CACHIX_NAME }} -- bash -c "$BUILD"
@@ -553,7 +568,10 @@ jobs:
           fi
 
           if [ -s outpaths.txt ]; then
-            # Clean build: push the toplevel closure. Fast and targeted.
+            # Push the toplevel closure(s) - one line per host that realised, so
+            # this is one or two paths. If only one of the two hosts built, the
+            # other's completed dependencies are already in the cache via
+            # watch-exec, so nothing is lost by not taking the fallback here.
             cachix push ${{ env.CACHIX_NAME }} $(cat outpaths.txt)
             exit 0
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,19 @@ jobs:
             # "user-environment.drv does not exist" failure on restore).
             keep-outputs = true
             keep-derivations = true
+            # The same extra substituters the real machines trust, from
+            # modules/nixos/toplevel/nix-nixos.nix. CI had NONE of them, so it
+            # COMPILED FROM SOURCE what every one of your machines simply
+            # downloads - run 1095 shows vicinae-0.25.0 being built locally
+            # even though vicinae publishes a cachix. Nothing new is trusted
+            # here: this is exactly the set already in the system config, with
+            # the same public keys.
+            #
+            # Note this is NOT covered by --accept-flake-config, which the
+            # builds do not pass (only `nix profile install` does), so an input
+            # flake's own nixConfig.extra-substituters is ignored regardless.
+            extra-substituters = https://hyprland.cachix.org https://cosmic.cachix.org https://walker.cachix.org https://claude-code.cachix.org https://vicinae.cachix.org https://catppuccin.cachix.org
+            extra-trusted-public-keys = hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc= cosmic.cachix.org-1:Dya9IyXD4xdBehWjrkPv6rtxpmMdRel02smYzA85dPE= walker.cachix.org-1:fG8q+uAaMqhsMxWjwvk0IMb4mFPFLqHjuvfwQxE4oJM= claude-code.cachix.org-1:YeXf2aNu7UTX8Vwrze0za1WEDS+4DuI2kVeWEE4fsRk= vicinae.cachix.org-1:1kDrfienkGHPYbkpNj1mWTr7Fm1+zcenzgTizIcI3oc= catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732n/9sI=
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             download-attempts = 15
@@ -332,6 +345,11 @@ jobs:
           - vesktop
           - signal-desktop
           - tor-browser
+          # Added on evidence, not guesswork: thunderbird-unwrapped is what run
+          # 754 spent its entire 300-minute budget compiling when nixpkgs had
+          # bumped ahead of Hydra. It is ~340 MiB and exactly the Hydra-lag
+          # window this matrix exists to cover.
+          - thunderbird
     env:
       NIXPKGS_ALLOW_UNFREE: 1
       # Needed by the notifier below. Without it env.WEBHOOK_ID is empty and
@@ -346,6 +364,19 @@ jobs:
         with:
           flakehub: false
           extra-conf: |
+            # The same extra substituters the real machines trust, from
+            # modules/nixos/toplevel/nix-nixos.nix. CI had NONE of them, so it
+            # COMPILED FROM SOURCE what every one of your machines simply
+            # downloads - run 1095 shows vicinae-0.25.0 being built locally
+            # even though vicinae publishes a cachix. Nothing new is trusted
+            # here: this is exactly the set already in the system config, with
+            # the same public keys.
+            #
+            # Note this is NOT covered by --accept-flake-config, which the
+            # builds do not pass (only `nix profile install` does), so an input
+            # flake's own nixConfig.extra-substituters is ignored regardless.
+            extra-substituters = https://hyprland.cachix.org https://cosmic.cachix.org https://walker.cachix.org https://claude-code.cachix.org https://vicinae.cachix.org https://catppuccin.cachix.org
+            extra-trusted-public-keys = hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc= cosmic.cachix.org-1:Dya9IyXD4xdBehWjrkPv6rtxpmMdRel02smYzA85dPE= walker.cachix.org-1:fG8q+uAaMqhsMxWjwvk0IMb4mFPFLqHjuvfwQxE4oJM= claude-code.cachix.org-1:YeXf2aNu7UTX8Vwrze0za1WEDS+4DuI2kVeWEE4fsRk= vicinae.cachix.org-1:1kDrfienkGHPYbkpNj1mWTr7Fm1+zcenzgTizIcI3oc= catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732n/9sI=
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             download-attempts = 15
@@ -576,6 +607,19 @@ jobs:
             # "user-environment.drv does not exist" failure on restore).
             keep-outputs = true
             keep-derivations = true
+            # The same extra substituters the real machines trust, from
+            # modules/nixos/toplevel/nix-nixos.nix. CI had NONE of them, so it
+            # COMPILED FROM SOURCE what every one of your machines simply
+            # downloads - run 1095 shows vicinae-0.25.0 being built locally
+            # even though vicinae publishes a cachix. Nothing new is trusted
+            # here: this is exactly the set already in the system config, with
+            # the same public keys.
+            #
+            # Note this is NOT covered by --accept-flake-config, which the
+            # builds do not pass (only `nix profile install` does), so an input
+            # flake's own nixConfig.extra-substituters is ignored regardless.
+            extra-substituters = https://hyprland.cachix.org https://cosmic.cachix.org https://walker.cachix.org https://claude-code.cachix.org https://vicinae.cachix.org https://catppuccin.cachix.org
+            extra-trusted-public-keys = hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc= cosmic.cachix.org-1:Dya9IyXD4xdBehWjrkPv6rtxpmMdRel02smYzA85dPE= walker.cachix.org-1:fG8q+uAaMqhsMxWjwvk0IMb4mFPFLqHjuvfwQxE4oJM= claude-code.cachix.org-1:YeXf2aNu7UTX8Vwrze0za1WEDS+4DuI2kVeWEE4fsRk= vicinae.cachix.org-1:1kDrfienkGHPYbkpNj1mWTr7Fm1+zcenzgTizIcI3oc= catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732n/9sI=
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             download-attempts = 15

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,16 @@ jobs:
           # cache without bound for no benefit, since nothing ever substitutes
           # it. Everything else the installer produces is version-stable and
           # deduplicates, so a narrow exclusion is enough.
-          nix path-info --all | grep -v -e '\.drv$' -e '-self-test-' | cachix push ${{ env.CACHIX_NAME }}
+          # Not a bare pipeline: GitHub runs these with `bash -e`, not
+          # `-o pipefail`, so a failing `nix path-info` would be masked - cachix
+          # would read empty stdin, report nothing to push and exit 0, and the
+          # run would look fine while caching nothing. Materialise the list
+          # first so that failure is visible.
+          if ! nix path-info --all > allpaths.txt; then
+            echo "::warning::nix path-info failed - nothing could be pushed this run."
+            exit 0
+          fi
+          grep -v -e '\.drv$' -e '-self-test-' allpaths.txt | cachix push ${{ env.CACHIX_NAME }}
 
       - name: Check for Dead Code (deadnix)
         continue-on-error: true
@@ -230,6 +239,9 @@ jobs:
           fi
           if [ "${{ steps.cachix_setup.outcome }}" == "failure" ]; then
             ISSUES="${ISSUES}- Cachix CLI setup failed (no binary-cache substituter this run, no functional impact)"$'\n'
+          fi
+          if [ "${{ steps.cachix_push.outcome }}" == "failure" ]; then
+            ISSUES="${ISSUES}- Cachix push failed (flake check output wasn't cached)"$'\n'
           fi
           jq -n --arg content "⚠️ flake-check: non-critical CI infra issue(s), job still succeeded:"$'\n'"${ISSUES}Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
           curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
@@ -327,7 +339,13 @@ jobs:
         if: always() && steps.cachix_setup.outcome == 'success'
         continue-on-error: true
         env:
+          # CACHIX_AUTH_TOKEN is the one cachix actually reads. Without it this
+          # step failed with "Neither auth token nor signing key are present."
+          # on every leg of every run, and continue-on-error hid it - the job
+          # still reported success while pushing nothing. CACHIX_TOKEN is only
+          # this script's own "is a token configured" guard.
           CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
           if [ -z "$CACHIX_TOKEN" ]; then
             echo "Skipping Cachix push: no auth token found (likely a fork)."
@@ -352,7 +370,16 @@ jobs:
           # cache without bound for no benefit, since nothing ever substitutes
           # it. Everything else the installer produces is version-stable and
           # deduplicates, so a narrow exclusion is enough.
-          nix path-info --all | grep -v -e '\.drv$' -e '-self-test-' | cachix push ${{ env.CACHIX_NAME }}
+          # Not a bare pipeline: GitHub runs these with `bash -e`, not
+          # `-o pipefail`, so a failing `nix path-info` would be masked - cachix
+          # would read empty stdin, report nothing to push and exit 0, and the
+          # run would look fine while caching nothing. Materialise the list
+          # first so that failure is visible.
+          if ! nix path-info --all > allpaths.txt; then
+            echo "::warning::nix path-info failed - nothing could be pushed this run."
+            exit 0
+          fi
+          grep -v -e '\.drv$' -e '-self-test-' allpaths.txt | cachix push ${{ env.CACHIX_NAME }}
 
   build-x86_64:
     needs: prewarm-cache
@@ -567,11 +594,14 @@ jobs:
             exit 0
           fi
 
-          if [ -s outpaths.txt ]; then
-            # Push the toplevel closure(s) - one line per host that realised, so
-            # this is one or two paths. If only one of the two hosts built, the
-            # other's completed dependencies are already in the cache via
-            # watch-exec, so nothing is lost by not taking the fallback here.
+          # Gate on the build's OUTCOME, not merely on outpaths.txt being
+          # non-empty. With two hosts, one can realise while the other fails -
+          # outpaths.txt then holds a single path, the targeted branch would be
+          # taken, and the failed host's completed dependencies would rely
+          # entirely on watch-exec having been available. Requiring a clean
+          # build before taking the fast path means any partial failure falls
+          # through to the whole-store push instead.
+          if [ "${{ steps.build.outcome }}" = "success" ] && [ -s outpaths.txt ]; then
             cachix push ${{ env.CACHIX_NAME }} $(cat outpaths.txt)
             exit 0
           fi
@@ -588,7 +618,7 @@ jobs:
           # filter (on by default) drops every path already present in
           # cache.nixos.org, so this uploads only what this repo actually
           # produced, not a copy of nixpkgs.
-          echo "No toplevel output path - pushing every valid store path instead."
+          echo "Build did not fully succeed - pushing every valid store path instead."
           # -self-test-: the Determinate installer writes a self-test path per
           # run whose name carries a timestamp (self-test-bash-1787097653189,
           # self-test-zsh-...), so it is a brand-new store path every single
@@ -596,7 +626,16 @@ jobs:
           # cache without bound for no benefit, since nothing ever substitutes
           # it. Everything else the installer produces is version-stable and
           # deduplicates, so a narrow exclusion is enough.
-          nix path-info --all | grep -v -e '\.drv$' -e '-self-test-' | cachix push ${{ env.CACHIX_NAME }}
+          # Not a bare pipeline: GitHub runs these with `bash -e`, not
+          # `-o pipefail`, so a failing `nix path-info` would be masked - cachix
+          # would read empty stdin, report nothing to push and exit 0, and the
+          # run would look fine while caching nothing. Materialise the list
+          # first so that failure is visible.
+          if ! nix path-info --all > allpaths.txt; then
+            echo "::warning::nix path-info failed - nothing could be pushed this run."
+            exit 0
+          fi
+          grep -v -e '\.drv$' -e '-self-test-' allpaths.txt | cachix push ${{ env.CACHIX_NAME }}
 
       # Ordered directly after the Cachix push and before the diagnostic
       # steps: these two are the only things in the job that persist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,15 @@ jobs:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
           nix profile install --accept-flake-config nixpkgs#cachix
-          cachix use ${{ env.CACHIX_NAME }}
+          # NOT fatal, and deliberately so. `cachix use` configures this cache as
+          # a SUBSTITUTER - it affects downloading and has nothing to do with
+          # pushing. Every push step in this workflow is gated on this step's
+          # outcome, so letting `cachix use` fail the step meant a transient
+          # substituter-config hiccup silently disabled ALL pushing even with a
+          # perfectly valid token. The gate now reflects what it claims to:
+          # whether the cachix CLI is installed and usable.
+          cachix use ${{ env.CACHIX_NAME }} \
+            || echo "::warning::cachix use failed - this cache is not configured as a substituter for this job. Pushing is unaffected."
 
       # continue-on-error so the push below still runs. `nix flake check
       # --all-systems` realises real derivations (IFD, every host's closure
@@ -312,7 +320,11 @@ jobs:
           fi
           jq -n --arg h "$HEAD" --arg b "$BODY" --arg u "$RUN_URL" \
             '{content: ($h + "\n" + $b + "\n" + $u)}' > payload.json
-          curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
+          # --fail so a rotated/revoked webhook is not reported as delivered, and
+          # `|| echo` so the notice never fails the step (and is never the last
+          # command left returning non-zero under bash -e).
+          curl -sS --fail -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL" \
+            || echo "::warning::Discord webhook delivery failed - the notification above was NOT sent."
 
 
 
@@ -390,7 +402,15 @@ jobs:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
           nix profile install --accept-flake-config nixpkgs#cachix
-          cachix use ${{ env.CACHIX_NAME }}
+          # NOT fatal, and deliberately so. `cachix use` configures this cache as
+          # a SUBSTITUTER - it affects downloading and has nothing to do with
+          # pushing. Every push step in this workflow is gated on this step's
+          # outcome, so letting `cachix use` fail the step meant a transient
+          # substituter-config hiccup silently disabled ALL pushing even with a
+          # perfectly valid token. The gate now reflects what it claims to:
+          # whether the cachix CLI is installed and usable.
+          cachix use ${{ env.CACHIX_NAME }} \
+            || echo "::warning::cachix use failed - this cache is not configured as a substituter for this job. Pushing is unaffected."
 
       # Built via the flake's own nixosConfigurations.nixos-desktop.pkgs
       # rather than plain nixpkgs#<attr>, so this is the exact same
@@ -524,7 +544,11 @@ jobs:
           fi
           jq -n --arg h "⚠️ **pre-warm ${{ matrix.attr }} - problem**" --arg b "$WARN" --arg u "$RUN_URL" \
             '{content: ($h + "\n" + $b + "\n" + $u)}' > payload.json
-          curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
+          # --fail so a rotated/revoked webhook is not reported as delivered, and
+          # `|| echo` so the notice never fails the step (and is never the last
+          # command left returning non-zero under bash -e).
+          curl -sS --fail -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL" \
+            || echo "::warning::Discord webhook delivery failed - the notification above was NOT sent."
 
   build-x86_64:
     needs: prewarm-cache
@@ -670,13 +694,13 @@ jobs:
           # SAME run would compute an identical primary-key (run_id and
           # run_attempt are shared across a matrix), so the second save would
           # collide with the first and one host's store would be lost.
-          primary-key: nix-${{ runner.os }}-${{ matrix.host }}-${{ hashFiles('flake.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}-${{ matrix.host }}-${{ github.run_id }}-${{ github.run_attempt }}
           # Same-lock AND same-host only - see the flake-check job for the
           # same-lock rationale. Restoring the other host's store would work
           # (Nix stores are additive) but would pull a large archive whose
           # host-specific half is useless here.
           restore-prefixes-first-match: |
-            nix-${{ runner.os }}-${{ matrix.host }}-${{ hashFiles('flake.lock') }}
+            nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}-${{ matrix.host }}
 
       - name: Verify Restored Store
         # Best-effort, and now declared as such. The `|| true` below already
@@ -709,7 +733,15 @@ jobs:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
           nix profile install --accept-flake-config nixpkgs#cachix
-          cachix use ${{ env.CACHIX_NAME }}
+          # NOT fatal, and deliberately so. `cachix use` configures this cache as
+          # a SUBSTITUTER - it affects downloading and has nothing to do with
+          # pushing. Every push step in this workflow is gated on this step's
+          # outcome, so letting `cachix use` fail the step meant a transient
+          # substituter-config hiccup silently disabled ALL pushing even with a
+          # perfectly valid token. The gate now reflects what it claims to:
+          # whether the cachix CLI is installed and usable.
+          cachix use ${{ env.CACHIX_NAME }} \
+            || echo "::warning::cachix use failed - this cache is not configured as a substituter for this job. Pushing is unaffected."
 
       # Wrapped in `cachix watch-exec`, which registers a Nix post-build hook
       # and uploads each store path the moment it is built, in parallel with
@@ -867,7 +899,7 @@ jobs:
         continue-on-error: true
         uses: nix-community/cache-nix-action/save@v7
         with:
-          primary-key: nix-${{ runner.os }}-${{ matrix.host }}-${{ hashFiles('flake.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}-${{ matrix.host }}-${{ github.run_id }}-${{ github.run_attempt }}
           gc-max-store-size-linux: 7000000000
           # Deliberately NO purge-* options. Purging needs an `actions: write`
           # permission this job doesn't grant, so they were always a silent
@@ -978,6 +1010,75 @@ jobs:
           fi
           jq -n --arg h "$HEAD" --arg b "$BODY" --arg u "$RUN_URL" \
             '{content: ($h + "\n" + $b + "\n" + $u)}' > payload.json
-          curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
+          # --fail so a rotated/revoked webhook is not reported as delivered, and
+          # `|| echo` so the notice never fails the step (and is never the last
+          # command left returning non-zero under bash -e).
+          curl -sS --fail -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL" \
+            || echo "::warning::Discord webhook delivery failed - the notification above was NOT sent."
 
+  # A JOB-LEVEL watchdog, deliberately on its own runner.
+  #
+  # Run 1111 is why this exists. Its build runner died outright: the job ended
+  # with "Build x86_64 Configurations" still marked in_progress, "Push to
+  # Cachix" still marked pending, and the logs returning HTTP 404 because they
+  # were never uploaded. Every other notifier in this workflow lives INSIDE the
+  # job it reports on, so when the runner dies there is nothing left to run them
+  # - the single worst failure this workflow can suffer was also the only one
+  # that told nobody at all.
+  #
+  # needs.<job>.result is filled in by GitHub regardless of how the job ended,
+  # and this job runs on a different machine, so it survives what the in-job
+  # notifiers cannot. On a matrix, .result aggregates: 'failure' if any leg
+  # failed.
+  #
+  # if: always() - without a status function this would be skipped for exactly
+  # the failures it exists to report.
+  report:
+    needs: [flake-check, prewarm-cache, build-x86_64]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
+    steps:
+      - name: Notify on job-level failure
+        if: always() && env.WEBHOOK_ID != ''
+        continue-on-error: true
+        env:
+          WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          FLAKE_CHECK: ${{ needs.flake-check.result }}
+          PREWARM: ${{ needs.prewarm-cache.result }}
+          BUILD: ${{ needs.build-x86_64.result }}
+        run: |
+          BAD=""
+          bad() { BAD="${BAD}🔴 $1"$'\n'; }
 
+          # prewarm-cache is job-level continue-on-error, so its result is
+          # 'success' even when legs fail - its own per-leg notifier covers it
+          # and is not second-guessed here.
+          if [ "$BUILD" = "failure" ] || [ "$BUILD" = "cancelled" ]; then
+            bad "build-x86_64 ended: \`$BUILD\`"
+          fi
+          if [ "$FLAKE_CHECK" = "failure" ] || [ "$FLAKE_CHECK" = "cancelled" ]; then
+            bad "flake-check ended: \`$FLAKE_CHECK\`"
+          fi
+
+          # Silent whenever every job reached a normal end, so this never
+          # duplicates a green run.
+          if [ -z "$BAD" ]; then
+            echo "All jobs reached a normal end - no job-level notification sent."
+            exit 0
+          fi
+
+          jq -n \
+            --arg h "🚨 **build run ended badly (job-level backstop)**" \
+            --arg b "$BAD" \
+            --arg n "If no per-job notice arrived alongside this one, the runner itself died - in that case the push step never ran and NOTHING from that job reached Cachix." \
+            --arg u "$RUN_URL" \
+            '{content: ($h + "\n" + $b + "\n" + $n + "\n" + $u)}' > payload.json
+          # --fail so a rotated/revoked webhook is not reported as delivered, and
+          # `|| echo` so the notice never fails the step (and is never the last
+          # command left returning non-zero under bash -e).
+          curl -sS --fail -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL" \
+            || echo "::warning::Discord webhook delivery failed - the notification above was NOT sent."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,13 @@ jobs:
             nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
 
       - name: Verify Restored Store
+        # Best-effort, and now declared as such. The `|| true` below already
+        # made this practically unfailable, but the guarantee lived in the
+        # command rather than the step: drop that `|| true` in a future edit
+        # and a store-verify hiccup would silently skip the Cachix push AND
+        # the store-cache save, because neither carries a status function that
+        # survives a hard failure here.
+        continue-on-error: true
         run: |
           # A restored cache can carry db registrations whose files never
           # made it into the archive (snapshot of a killed build - bit us on
@@ -483,6 +490,13 @@ jobs:
             nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
 
       - name: Verify Restored Store
+        # Best-effort, and now declared as such. The `|| true` below already
+        # made this practically unfailable, but the guarantee lived in the
+        # command rather than the step: drop that `|| true` in a future edit
+        # and a store-verify hiccup would silently skip the Cachix push AND
+        # the store-cache save, because neither carries a status function that
+        # survives a hard failure here.
+        continue-on-error: true
         run: |
           # A restored cache can carry db registrations whose files never
           # made it into the archive (snapshot of a killed build - bit us on

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,8 +165,14 @@ jobs:
           CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
+          # pipefail: the `| tee` below would otherwise mask cachix's exit code,
+          # reintroducing exactly the silent-success failure this step exists
+          # to avoid.
+          set -o pipefail
+
           if [ -z "$CACHIX_TOKEN" ]; then
             echo "Skipping Cachix push: no auth token found (likely a fork)."
+            echo "pushed=skipped" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           # No single output path to name here - flake check has many roots -
@@ -186,9 +192,17 @@ jobs:
           # first so that failure is visible.
           if ! nix path-info --all > allpaths.txt; then
             echo "::warning::nix path-info failed - nothing could be pushed this run."
+            echo "pushed=error" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          grep -v -e '\.drv$' -e '-self-test-' allpaths.txt | cachix push ${{ env.CACHIX_NAME }}
+          grep -v -e '\.drv$' -e '-self-test-' allpaths.txt > topush.txt || true
+          if [ ! -s topush.txt ]; then
+            echo "Nothing left to push after filtering."
+            echo "pushed=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          cachix push ${{ env.CACHIX_NAME }} < topush.txt 2>&1 | tee push.log
+          echo "pushed=$(grep -c '^Pushing ' push.log || true)" >> "$GITHUB_OUTPUT"
 
       - name: Check for Dead Code (deadnix)
         continue-on-error: true
@@ -203,14 +217,7 @@ jobs:
             echo "HAS_DEAD_CODE=false" >> $GITHUB_ENV
           fi
 
-      - name: Notify Dead Code (x86_64)
-        if: env.HAS_DEAD_CODE == 'true' && env.WEBHOOK_ID != ''
-        continue-on-error: true
-        env:
-          WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-        run: |
-          jq -n --arg prefix "🧹 **Dead Nix Code Detected (x86_64)** Consider cleaning up:" --arg report "$DEADCODE_REPORT" '{content: ($prefix + "\n```text\n" + $report + "\n```")}' > payload.json
-          curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
+
 
       - name: Report Flake Check Status
         if: always()
@@ -221,37 +228,80 @@ jobs:
           fi
           echo "flake check: ${{ steps.flake_check.outcome }}"
 
-      - name: Notify on Failure (flake check)
-        if: failure() && env.WEBHOOK_ID != ''
+      # ONE consolidated notice per job, replacing the previous separate ones.
+      # The old split was structurally unsound: hard failures fired on
+      # failure() while infra problems fired on success(), so a FAILED job
+      # suppressed the infra report entirely - you would never learn that
+      # Cachix had broken too. It also let a condition name a step the message
+      # body never mentioned, which is how a notice could fire listing nothing.
+      # Collecting every finding in the same step that decides whether to send
+      # removes both classes of bug.
+      #
+      # Silent on a clean run: no findings, no message.
+      #
+      # Shell note: findings are appended inside `if` blocks, never as
+      # `[ test ] && append`. Under `bash -e` a false test makes that an `&&`
+      # list returning non-zero, which aborts the step - the notifier would
+      # stop at the first finding that did not apply.
+      - name: Notify (flake-check)
+        if: always() && env.WEBHOOK_ID != ''
         continue-on-error: true
         env:
           WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          jq -n --arg content "🚨 Flake check failed! Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
+          CRIT=""; WARN=""; INFO=""; NOTE=""
+          crit() { CRIT="${CRIT}🔴 $1"$'\n'; }
+          warn() { WARN="${WARN}🟠 $1"$'\n'; }
+          info() { INFO="${INFO}🔵 $1"$'\n'; }
+          # note() rides along in a message that is being sent anyway, but never
+          # causes one on its own. Routine facts - "0 new paths, everything was
+          # already cached" - are true on every warm run, so promoting them to a
+          # trigger would mean a Discord message after every single green build,
+          # and a channel nobody reads is the same as no notifications at all.
+          note() { NOTE="${NOTE}⚪ $1"$'\n'; }
+          if [ "${{ steps.flake_check.outcome }}" = "failure" ]; then
+            crit "\`nix flake check --all-systems\` failed - its build output was still pushed to Cachix"
+          fi
+          if [ "${{ steps.cachix_setup.outcome }}" = "failure" ]; then
+            warn "Cachix CLI setup failed - nothing could be pushed this run"
+          fi
+          if [ "${{ steps.cachix_push.outcome }}" = "failure" ]; then
+            warn "Cachix push failed - flake check output was not cached"
+          fi
+          if [ "${{ steps.cache_restore.outcome }}" = "failure" ]; then
+            warn "Nix store cache restore failed - this run evaluated cold"
+          fi
+          P="${{ steps.cachix_push.outputs.pushed }}"
+          if [ "$P" = "error" ]; then
+            warn "\`nix path-info\` failed - the store could not be listed, so nothing was pushed"
+          elif [ "$P" = "0" ]; then
+            note "Cachix push uploaded 0 new paths"
+          elif [ -n "$P" ] && [ "$P" != "skipped" ]; then
+            note "Pushed $P new store path(s) to Cachix"
+          fi
+          if [ "${{ env.HAS_DEAD_CODE }}" = "true" ]; then
+            info "Dead Nix code detected:"$'\n'"\`\`\`text"$'\n'"$DEADCODE_REPORT"$'\n'"\`\`\`"
+          fi
+
+          # Send decision uses CRIT/WARN/INFO only; NOTE rides along.
+          BODY="${CRIT}${WARN}${INFO}${NOTE}"
+          if [ -z "${CRIT}${WARN}${INFO}" ]; then
+            echo "Nothing to report - no notification sent."
+            exit 0
+          fi
+          if [ -n "$CRIT" ]; then
+            HEAD="🚨 **flake-check - failed**"
+          elif [ -n "$WARN" ]; then
+            HEAD="⚠️ **flake-check - finished, but with problems**"
+          else
+            HEAD="ℹ️ **flake-check**"
+          fi
+          jq -n --arg h "$HEAD" --arg b "$BODY" --arg u "$RUN_URL" \
+            '{content: ($h + "\n" + $b + "\n" + $u)}' > payload.json
           curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
 
-      # Non-critical infra (store cache / cachix) failing must not fail the
-      # job, but should still be surfaced - this reports it separately from
-      # the hard-failure notice above, which only fires for real flake-check
-      # breakage.
-      - name: Notify Non-Critical Issues (flake-check)
-        if: success() && env.WEBHOOK_ID != '' && (steps.cache_restore.outcome == 'failure' || steps.cachix_setup.outcome == 'failure' || steps.cachix_push.outcome == 'failure')
-        continue-on-error: true
-        env:
-          WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-        run: |
-          ISSUES=""
-          if [ "${{ steps.cache_restore.outcome }}" == "failure" ]; then
-            ISSUES="${ISSUES}- Nix store cache restore failed (this run built cold, no functional impact)"$'\n'
-          fi
-          if [ "${{ steps.cachix_setup.outcome }}" == "failure" ]; then
-            ISSUES="${ISSUES}- Cachix CLI setup failed (no binary-cache substituter this run, no functional impact)"$'\n'
-          fi
-          if [ "${{ steps.cachix_push.outcome }}" == "failure" ]; then
-            ISSUES="${ISSUES}- Cachix push failed (flake check output wasn't cached)"$'\n'
-          fi
-          jq -n --arg content "⚠️ flake-check: non-critical CI infra issue(s), job still succeeded:"$'\n'"${ISSUES}Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
-          curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
+
 
   # Builds the handful of large, independently-buildable packages in the
   # nixos-desktop closure (mostly Electron apps) in parallel, each with its
@@ -284,6 +334,10 @@ jobs:
           - tor-browser
     env:
       NIXPKGS_ALLOW_UNFREE: 1
+      # Needed by the notifier below. Without it env.WEBHOOK_ID is empty and
+      # the notice never fires - which is why this job stayed silent while its
+      # push step failed on every leg of every run.
+      WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
     steps:
       - uses: actions/checkout@v4
 
@@ -343,6 +397,7 @@ jobs:
           fi
 
       - name: Push ${{ matrix.attr }} to Cachix
+        id: prewarm_push
         if: always() && steps.cachix_setup.outcome == 'success'
         continue-on-error: true
         env:
@@ -354,13 +409,20 @@ jobs:
           CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
+          # pipefail: the `| tee` below would otherwise mask cachix's exit code,
+          # reintroducing exactly the silent-success failure this step exists
+          # to avoid.
+          set -o pipefail
+
           if [ -z "$CACHIX_TOKEN" ]; then
             echo "Skipping Cachix push: no auth token found (likely a fork)."
+            echo "pushed=skipped" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [ -s out.txt ]; then
-            cachix push ${{ env.CACHIX_NAME }} $(cat out.txt)
+            cachix push ${{ env.CACHIX_NAME }} $(cat out.txt) 2>&1 | tee push.log
+            echo "pushed=$(grep -c '^Pushing ' push.log || true)" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -384,9 +446,54 @@ jobs:
           # first so that failure is visible.
           if ! nix path-info --all > allpaths.txt; then
             echo "::warning::nix path-info failed - nothing could be pushed this run."
+            echo "pushed=error" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          grep -v -e '\.drv$' -e '-self-test-' allpaths.txt | cachix push ${{ env.CACHIX_NAME }}
+          grep -v -e '\.drv$' -e '-self-test-' allpaths.txt > topush.txt || true
+          if [ ! -s topush.txt ]; then
+            echo "Nothing left to push after filtering."
+            echo "pushed=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          cachix push ${{ env.CACHIX_NAME }} < topush.txt 2>&1 | tee push.log
+          echo "pushed=$(grep -c '^Pushing ' push.log || true)" >> "$GITHUB_OUTPUT"
+
+      # This job had NO notification at all, which is exactly why its push step
+      # could fail with "Neither auth token nor signing key are present." on
+      # every leg of every run without anyone noticing: the job is
+      # continue-on-error at the job level, so its own red status is invisible
+      # in the workflow result too. Reports per matrix leg, and only when
+      # there is something wrong - a warm leg with nothing to push is silent.
+      - name: Notify (pre-warm ${{ matrix.attr }})
+        if: always() && env.WEBHOOK_ID != ''
+        continue-on-error: true
+        env:
+          WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          WARN=""
+          warn() { WARN="${WARN}🟠 $1"$'\n'; }
+
+          if [ "${{ steps.prewarm.outcome }}" = "failure" ]; then
+            warn "\`${{ matrix.attr }}\` failed to build - the main build will have to build it"
+          fi
+          if [ "${{ steps.cachix_setup.outcome }}" = "failure" ]; then
+            warn "Cachix CLI setup failed - this leg cached nothing"
+          fi
+          if [ "${{ steps.prewarm_push.outcome }}" = "failure" ]; then
+            warn "Cachix push failed - \`${{ matrix.attr }}\` was built but not cached"
+          fi
+          if [ "${{ steps.prewarm_push.outputs.pushed }}" = "error" ]; then
+            warn "\`nix path-info\` failed - nothing could be pushed"
+          fi
+
+          if [ -z "$WARN" ]; then
+            echo "Nothing to report - no notification sent."
+            exit 0
+          fi
+          jq -n --arg h "⚠️ **pre-warm ${{ matrix.attr }} - problem**" --arg b "$WARN" --arg u "$RUN_URL" \
+            '{content: ($h + "\n" + $b + "\n" + $u)}' > payload.json
+          curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
 
   build-x86_64:
     needs: prewarm-cache
@@ -603,8 +710,14 @@ jobs:
           CACHIX_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
+          # pipefail: the `| tee` below would otherwise mask cachix's exit code,
+          # reintroducing exactly the silent-success failure this step exists
+          # to avoid.
+          set -o pipefail
+
           if [ -z "$CACHIX_TOKEN" ]; then
             echo "Skipping Cachix push: no auth token found (likely a fork)."
+            echo "pushed=skipped" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -616,7 +729,8 @@ jobs:
           # build before taking the fast path means any partial failure falls
           # through to the whole-store push instead.
           if [ "${{ steps.build.outcome }}" = "success" ] && [ -s outpaths.txt ]; then
-            cachix push ${{ env.CACHIX_NAME }} $(cat outpaths.txt)
+            cachix push ${{ env.CACHIX_NAME }} $(cat outpaths.txt) 2>&1 | tee push.log
+            echo "pushed=$(grep -c '^Pushing ' push.log || true)" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -647,9 +761,17 @@ jobs:
           # first so that failure is visible.
           if ! nix path-info --all > allpaths.txt; then
             echo "::warning::nix path-info failed - nothing could be pushed this run."
+            echo "pushed=error" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          grep -v -e '\.drv$' -e '-self-test-' allpaths.txt | cachix push ${{ env.CACHIX_NAME }}
+          grep -v -e '\.drv$' -e '-self-test-' allpaths.txt > topush.txt || true
+          if [ ! -s topush.txt ]; then
+            echo "Nothing left to push after filtering."
+            echo "pushed=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          cachix push ${{ env.CACHIX_NAME }} < topush.txt 2>&1 | tee push.log
+          echo "pushed=$(grep -c '^Pushing ' push.log || true)" >> "$GITHUB_OUTPUT"
 
       # Ordered directly after the Cachix push and before the diagnostic
       # steps: these two are the only things in the job that persist
@@ -703,37 +825,84 @@ jobs:
             echo "No output paths were built."
           fi
 
-      - name: Notify on Failure (x86_64)
-        if: failure() && env.WEBHOOK_ID != ''
+      # ONE consolidated notice per job, replacing the previous separate ones.
+      # The old split was structurally unsound: hard failures fired on
+      # failure() while infra problems fired on success(), so a FAILED job
+      # suppressed the infra report entirely - you would never learn that
+      # Cachix had broken too. It also let a condition name a step the message
+      # body never mentioned, which is how a notice could fire listing nothing.
+      # Collecting every finding in the same step that decides whether to send
+      # removes both classes of bug.
+      #
+      # Silent on a clean run: no findings, no message.
+      #
+      # Shell note: findings are appended inside `if` blocks, never as
+      # `[ test ] && append`. Under `bash -e` a false test makes that an `&&`
+      # list returning non-zero, which aborts the step - the notifier would
+      # stop at the first finding that did not apply.
+      - name: Notify (x86_64)
+        if: always() && env.WEBHOOK_ID != ''
         continue-on-error: true
         env:
           WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          jq -n --arg content "🚨 NixOS build failed on **x86_64** (whatever did build was still pushed to Cachix). Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
+          CRIT=""; WARN=""; INFO=""; NOTE=""
+          crit() { CRIT="${CRIT}🔴 $1"$'\n'; }
+          warn() { WARN="${WARN}🟠 $1"$'\n'; }
+          info() { INFO="${INFO}🔵 $1"$'\n'; }
+          # note() rides along in a message that is being sent anyway, but never
+          # causes one on its own. Routine facts - "0 new paths, everything was
+          # already cached" - are true on every warm run, so promoting them to a
+          # trigger would mean a Discord message after every single green build,
+          # and a channel nobody reads is the same as no notifications at all.
+          note() { NOTE="${NOTE}⚪ $1"$'\n'; }
+          if [ "${{ steps.build.outcome }}" = "failure" ]; then
+            crit "Build failed or timed out - whatever DID build was still pushed to Cachix"
+          fi
+          if [ "${{ steps.cachix_setup.outcome }}" = "failure" ]; then
+            warn "Cachix CLI setup failed - nothing could be pushed this run"
+          fi
+          if [ "${{ steps.cachix_push.outcome }}" = "failure" ]; then
+            warn "Cachix push failed - build output was not cached"
+          fi
+          if [ "${{ steps.cache_restore.outcome }}" = "failure" ]; then
+            warn "Nix store cache restore failed - this run built cold"
+          fi
+          if [ "${{ steps.cache_save.outcome }}" = "failure" ]; then
+            warn "Nix store cache save failed - the next run starts cold"
+          fi
+          P="${{ steps.cachix_push.outputs.pushed }}"
+          if [ "$P" = "error" ]; then
+            warn "\`nix path-info\` failed - the store could not be listed, so nothing was pushed"
+          elif [ "$P" = "0" ]; then
+            note "Cachix push uploaded 0 new paths"
+          elif [ -n "$P" ] && [ "$P" != "skipped" ]; then
+            note "Pushed $P new store path(s) to Cachix"
+          fi
+          # 0 pushed after a FAILED build is different from 0 after a clean one:
+          # --keep-going plus the whole-store fallback should have salvaged
+          # something, so nothing uploaded means the salvage path itself did not
+          # work. Worth waking someone for.
+          if [ "$P" = "0" ] && [ "${{ steps.build.outcome }}" = "failure" ]; then
+            warn "Build failed AND the fallback push uploaded nothing - partial results were NOT salvaged"
+          fi
+
+          # Send decision uses CRIT/WARN/INFO only; NOTE rides along.
+          BODY="${CRIT}${WARN}${INFO}${NOTE}"
+          if [ -z "${CRIT}${WARN}${INFO}" ]; then
+            echo "Nothing to report - no notification sent."
+            exit 0
+          fi
+          if [ -n "$CRIT" ]; then
+            HEAD="🚨 **build-x86_64 - failed**"
+          elif [ -n "$WARN" ]; then
+            HEAD="⚠️ **build-x86_64 - finished, but with problems**"
+          else
+            HEAD="ℹ️ **build-x86_64**"
+          fi
+          jq -n --arg h "$HEAD" --arg b "$BODY" --arg u "$RUN_URL" \
+            '{content: ($h + "\n" + $b + "\n" + $u)}' > payload.json
           curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
 
-      # Non-critical infra (store cache restore/save, cachix setup/push)
-      # failing must not fail the job, but should still be surfaced -
-      # reported separately from the hard-failure notice above, which only
-      # fires when the actual build step failed.
-      - name: Notify Non-Critical Issues (x86_64)
-        if: success() && env.WEBHOOK_ID != '' && (steps.cache_restore.outcome == 'failure' || steps.cachix_setup.outcome == 'failure' || steps.cachix_push.outcome == 'failure' || steps.cache_save.outcome == 'failure')
-        continue-on-error: true
-        env:
-          WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-        run: |
-          ISSUES=""
-          if [ "${{ steps.cache_restore.outcome }}" == "failure" ]; then
-            ISSUES="${ISSUES}- Nix store cache restore failed (this run built cold, no functional impact)"$'\n'
-          fi
-          if [ "${{ steps.cachix_setup.outcome }}" == "failure" ]; then
-            ISSUES="${ISSUES}- Cachix CLI setup failed (binary cache push skipped this run)"$'\n'
-          fi
-          if [ "${{ steps.cachix_push.outcome }}" == "failure" ]; then
-            ISSUES="${ISSUES}- Cachix push failed (build succeeded, but its outputs weren't cached)"$'\n'
-          fi
-          if [ "${{ steps.cache_save.outcome }}" == "failure" ]; then
-            ISSUES="${ISSUES}- Nix store cache save failed (no retry-resume cache for next run)"$'\n'
-          fi
-          jq -n --arg content "⚠️ build-x86_64: non-critical CI infra issue(s), job still succeeded:"$'\n'"${ISSUES}Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $content}' > payload.json
-          curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -532,6 +532,37 @@ jobs:
     # - a failed/skipped/timed-out leg there must never block the real build.
     if: always()
     runs-on: ubuntu-latest
+    # ONE HOST PER RUNNER, not both in a single job.
+    #
+    # Run 1110 built nixos-desktop alone in 12m44s and pushed cleanly. Run 1111
+    # added nixos-laptop to the same `nix build` and the runner DIED after 68
+    # minutes: the job ended with "Build x86_64 Configurations" still marked
+    # in_progress, "Push to Cachix" still marked pending, and the logs
+    # returning HTTP 404 because they were never uploaded.
+    #
+    # That is the one failure mode always() does NOT cover. always() runs a
+    # step after a failure, a timeout, or a cancellation - but when the runner
+    # itself dies there is nothing left to run the step, so the push is lost
+    # outright. Keeping each job inside a resource envelope a runner survives
+    # is therefore a push-reliability measure, not a performance tweak.
+    #
+    # Why it blew up: this job deliberately sets keep-outputs/keep-derivations
+    # (see Install Nix below) so a saved store cache never references pruned
+    # files. That retains every INTERMEDIATE output, not just the runtime
+    # closure, and the ~78 GiB nothing-but-nix frees was sized for one system
+    # closure. Two closures' worth of retained intermediates does not fit.
+    #
+    # A matrix also gives independent failure domains - the laptop dying can no
+    # longer cost us the desktop's push - and runs the two in parallel, so the
+    # wall clock is max(desktop, laptop) rather than their sum. fail-fast is
+    # off for the same reason: one host failing must never cancel the other's
+    # build, which would throw away exactly the paths we exist to cache.
+    strategy:
+      fail-fast: false
+      matrix:
+        host:
+          - nixos-desktop
+          - nixos-laptop
     # Stay below GitHub's hard 360-minute job kill: a hard-killed job loses
     # its cache-save and cachix-flush steps, which is why retries used to
     # restart from zero.
@@ -635,10 +666,17 @@ jobs:
         continue-on-error: true
         uses: nix-community/cache-nix-action/restore@v7
         with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
-          # Same-lock only - see the flake-check job for the rationale.
+          # matrix.host is part of the key: without it both matrix legs of the
+          # SAME run would compute an identical primary-key (run_id and
+          # run_attempt are shared across a matrix), so the second save would
+          # collide with the first and one host's store would be lost.
+          primary-key: nix-${{ runner.os }}-${{ matrix.host }}-${{ hashFiles('flake.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          # Same-lock AND same-host only - see the flake-check job for the
+          # same-lock rationale. Restoring the other host's store would work
+          # (Nix stores are additive) but would pull a large archive whose
+          # host-specific half is useless here.
           restore-prefixes-first-match: |
-            nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+            nix-${{ runner.os }}-${{ matrix.host }}-${{ hashFiles('flake.lock') }}
 
       - name: Verify Restored Store
         # Best-effort, and now declared as such. The `|| true` below already
@@ -688,10 +726,9 @@ jobs:
       # --keep-going: when a derivation fails (broken dep, unfree, or a package
       # unsupported on this platform) keep building every other branch of the
       # graph, so one bad package doesn't cost us the whole closure.
-      # Builds nixos-desktop AND nixos-laptop: a rebuild on either machine
-      # after a flake bump should substitute rather than build, including
-      # the host-specific paths that differ between them.
-      - name: Build x86_64 Configurations
+      # One host per job - see the matrix on the job above for why both in a
+      # single `nix build` killed the runner and cost us the push entirely.
+      - name: Build ${{ matrix.host }}
         id: build
         timeout-minutes: 270
         env:
@@ -708,19 +745,13 @@ jobs:
              && cachix watch-exec --help > /dev/null 2>&1; then
             WATCH=1
           fi
-          # Both x86_64 hosts in ONE nix build on ONE runner, not two jobs:
-          # they share nearly their whole closure, so the laptop's marginal
-          # cost is only its host-specific derivations (home-manager
-          # generation, system-path, activation scripts) rather than a second
-          # full build. --keep-going means a failure in one still builds the
-          # other, and --print-out-paths writes one line per realised toplevel,
-          # so outpaths.txt may legitimately hold one path or two.
-          # Backslash continuations, not bare newlines: BUILD is handed to
-          # `bash -c`, which would otherwise read each line as its own command.
-          BUILD='nix build \
-                   .#nixosConfigurations.nixos-desktop.config.system.build.toplevel \
-                   .#nixosConfigurations.nixos-laptop.config.system.build.toplevel \
-                   --no-link --print-out-paths --keep-going --max-jobs 2 --cores 4 > outpaths.txt'
+          # Exactly one toplevel, so outpaths.txt holds at most one line.
+          # Kept on a single physical line on purpose: BUILD is handed to
+          # `bash -c`, which reads a bare newline as the end of one command and
+          # the start of another - an earlier version of this variable spanned
+          # several lines and would have run `nix build` with no arguments at
+          # all. If this ever needs wrapping again, use backslash continuations.
+          BUILD='nix build .#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel --no-link --print-out-paths --keep-going --max-jobs 2 --cores 4 > outpaths.txt'
           if [ "$WATCH" = 1 ]; then
             echo "Building under 'cachix watch-exec' - paths are pushed as they are built."
             cachix watch-exec ${{ env.CACHIX_NAME }} -- bash -c "$BUILD"
@@ -746,7 +777,7 @@ jobs:
       # runs on purpose: a store snapshot taken mid-build is internally
       # inconsistent, whereas Cachix uploads whole valid paths one at a time,
       # so a push cut short just means fewer paths, never a corrupt cache.
-      - name: Push to Cachix (x86_64)
+      - name: Push to Cachix (${{ matrix.host }})
         id: cachix_push
         if: always() && steps.cachix_setup.outcome == 'success'
         continue-on-error: true
@@ -766,12 +797,12 @@ jobs:
           fi
 
           # Gate on the build's OUTCOME, not merely on outpaths.txt being
-          # non-empty. With two hosts, one can realise while the other fails -
-          # outpaths.txt then holds a single path, the targeted branch would be
-          # taken, and the failed host's completed dependencies would rely
-          # entirely on watch-exec having been available. Requiring a clean
-          # build before taking the fast path means any partial failure falls
-          # through to the whole-store push instead.
+          # non-empty. --keep-going means the build can fail while still having
+          # realised plenty; --print-out-paths would then print nothing (the
+          # toplevel depends on everything) and an emptiness-only test would
+          # take neither branch usefully. Requiring a clean build before the
+          # targeted fast path means ANY failure falls through to the
+          # whole-store push, which is what actually salvages partial work.
           if [ "${{ steps.build.outcome }}" = "success" ] && [ -s outpaths.txt ]; then
             cachix push ${{ env.CACHIX_NAME }} $(cat outpaths.txt) 2>&1 | tee push.log
             echo "pushed=$(grep -c '^Pushing ' push.log || true)" >> "$GITHUB_OUTPUT"
@@ -836,7 +867,7 @@ jobs:
         continue-on-error: true
         uses: nix-community/cache-nix-action/save@v7
         with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          primary-key: nix-${{ runner.os }}-${{ matrix.host }}-${{ hashFiles('flake.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
           gc-max-store-size-linux: 7000000000
           # Deliberately NO purge-* options. Purging needs an `actions: write`
           # permission this job doesn't grant, so they were always a silent
@@ -859,7 +890,7 @@ jobs:
           echo "--- Swap ---"
           free -h
 
-      - name: Show Package Tree (x86_64)
+      - name: Show Package Tree (${{ matrix.host }})
         if: always()
         continue-on-error: true
         run: |
@@ -884,7 +915,7 @@ jobs:
       # `[ test ] && append`. Under `bash -e` a false test makes that an `&&`
       # list returning non-zero, which aborts the step - the notifier would
       # stop at the first finding that did not apply.
-      - name: Notify (x86_64)
+      - name: Notify (${{ matrix.host }})
         if: always() && env.WEBHOOK_ID != ''
         continue-on-error: true
         env:
@@ -939,11 +970,11 @@ jobs:
             exit 0
           fi
           if [ -n "$CRIT" ]; then
-            HEAD="🚨 **build-x86_64 - failed**"
+            HEAD="🚨 **build ${{ matrix.host }} - failed**"
           elif [ -n "$WARN" ]; then
-            HEAD="⚠️ **build-x86_64 - finished, but with problems**"
+            HEAD="⚠️ **build ${{ matrix.host }} - finished, but with problems**"
           else
-            HEAD="ℹ️ **build-x86_64**"
+            HEAD="ℹ️ **build ${{ matrix.host }}**"
           fi
           jq -n --arg h "$HEAD" --arg b "$BODY" --arg u "$RUN_URL" \
             '{content: ($h + "\n" + $b + "\n" + $u)}' > payload.json

--- a/.github/workflows/check-workflows.yml
+++ b/.github/workflows/check-workflows.yml
@@ -114,4 +114,8 @@ jobs:
           fi
           jq -n --arg h "$HEAD" --arg b "${CRIT}${WARN}" --arg u "$RUN_URL" \
             '{content: ($h + "\n" + $b + "\n" + $u)}' > payload.json
-          curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
+          # --fail so a rotated/revoked webhook is not reported as delivered, and
+          # `|| echo` so the notice never fails the step (and is never the last
+          # command left returning non-zero under bash -e).
+          curl -sS --fail -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL" \
+            || echo "::warning::Discord webhook delivery failed - the notification above was NOT sent."

--- a/.github/workflows/check-workflows.yml
+++ b/.github/workflows/check-workflows.yml
@@ -1,0 +1,117 @@
+name: "Check CI workflow files"
+
+# The build workflows are the only thing standing between a broken flake bump
+# and a machine that has to compile everything from source. Their failure mode
+# is quiet: a push step that authenticates with the wrong variable, a guard that
+# skips exactly when there is most to salvage, a `bash -c` string that silently
+# runs nothing. Every one of those shipped at some point and none turned a job
+# red. This workflow exists so the next one is caught by a machine instead of by
+# noticing months later that the cache is empty.
+
+env:
+  # Declared at workflow level so the notify step's `if:` can read it. Step-level
+  # env is not visible to that step's own `if:`.
+  WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
+
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/scripts/**"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/scripts/**"
+  # Weekly, independent of any edit: actions get deprecated, runner images
+  # change, and a workflow that was correct in August can rot by November
+  # without anybody touching the file.
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-workflows:
+    runs-on: ubuntu-latest
+    # Pure static analysis - no Nix, no builds. If this is not finished in a
+    # couple of minutes something is wrong.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install actionlint
+        run: |
+          set -o pipefail
+          curl -sSfL -o download-actionlint.bash \
+            https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash
+          bash download-actionlint.bash
+          ./actionlint --version
+
+      # Hard gate. actionlint's own analysis - unknown keys, bad `if:`
+      # expressions, invalid contexts, references to matrix values that do not
+      # exist, deprecated runner labels.
+      #
+      # -shellcheck= disables the shellcheck integration deliberately. It is run
+      # as a separate advisory step below because several of its findings are
+      # things this repo does ON PURPOSE: `cachix push <cache> $(cat out.txt)`
+      # relies on word splitting to turn one path per line into one argument
+      # per path, and SC2046 would have us quote it, which would pass the whole
+      # file as a single argument and break every push.
+      - name: actionlint
+        run: ./actionlint -shellcheck= .github/workflows/*.yml
+
+      # Advisory. Real shell smells do show up here, but so do the deliberate
+      # ones above, so it reports without gating.
+      - name: shellcheck (advisory)
+        id: shellcheck
+        continue-on-error: true
+        run: ./actionlint .github/workflows/*.yml
+
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet pyyaml
+
+      # Hard gate. The repo-specific invariants - every one of them a bug that
+      # actually happened here, with the run number that exposed it.
+      - name: Check workflow invariants
+        id: invariants
+        run: python3 .github/scripts/check-workflow-invariants.py
+
+      - name: Notify (workflow check)
+        # WEBHOOK_ID guard: on a fork without secrets the URL is malformed and
+        # this would curl a broken endpoint every run. continue-on-error: a
+        # Discord outage must not be the reason this check goes red.
+        if: always() && env.WEBHOOK_ID != ''
+        continue-on-error: true
+        env:
+          WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          CRIT=""; WARN=""
+          crit() { CRIT="${CRIT}🔴 $1"$'\n'; }
+          warn() { WARN="${WARN}🟠 $1"$'\n'; }
+
+          if [ "${{ steps.invariants.outcome }}" = "failure" ]; then
+            crit "A CI workflow invariant was violated - see the job log for which one"
+          fi
+          if [ "${{ steps.shellcheck.outcome }}" = "failure" ]; then
+            warn "shellcheck flagged something in a workflow \`run:\` block (advisory)"
+          fi
+
+          # Silent when everything holds. A channel that gets a message on every
+          # green run is a channel nobody reads.
+          if [ -z "${CRIT}${WARN}" ]; then
+            echo "Nothing to report - no notification sent."
+            exit 0
+          fi
+          if [ -n "$CRIT" ]; then
+            HEAD="🚨 **CI workflow check - failed**"
+          else
+            HEAD="⚠️ **CI workflow check - advisory**"
+          fi
+          jq -n --arg h "$HEAD" --arg b "${CRIT}${WARN}" --arg u "$RUN_URL" \
+            '{content: ($h + "\n" + $b + "\n" + $u)}' > payload.json
+          curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"

--- a/.github/workflows/tests-darwin.yml
+++ b/.github/workflows/tests-darwin.yml
@@ -78,7 +78,11 @@ jobs:
               --arg url "$RUN_URL" \
               '{content: "🧪 **Darwin Tests Failed** | `\($ref)` (\($event))\n```\n\($report)\n```\n🔗 \($url)"}' \
               > payload.json
-            curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
+            # --fail so a rotated/revoked webhook is not reported as delivered, and
+          # `|| echo` so the notice never fails the step (and is never the last
+          # command left returning non-zero under bash -e).
+          curl -sS --fail -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL" \
+            || echo "::warning::Discord webhook delivery failed - the notification above was NOT sent."
           fi
 
           exit 1

--- a/.github/workflows/tests-darwin.yml
+++ b/.github/workflows/tests-darwin.yml
@@ -45,7 +45,12 @@ jobs:
         run: bash templates/tests/darwin/test-minimal-defaults/check-darwin-minimal-defaults.sh
 
       - name: Summary and notify on failure
-        if: always()
+        # always() && WEBHOOK_ID: on a fork without secrets the webhook URL is
+        # malformed, so this would curl a broken endpoint on every single run.
+        # continue-on-error: a Discord outage must never turn a passing test
+        # suite into a failed job - the notice is secondary to the result.
+        if: always() && env.WEBHOOK_ID != ''
+        continue-on-error: true
         env:
           WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/tests-nixos.yml
+++ b/.github/workflows/tests-nixos.yml
@@ -174,7 +174,11 @@ jobs:
               --arg url "$RUN_URL" \
               '{content: "🧪 **NixOS Tests Failed** | `\($ref)` (\($event))\n```\n\($report)\n```\n🔗 \($url)"}' \
               > payload.json
-            curl -s -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL"
+            # --fail so a rotated/revoked webhook is not reported as delivered, and
+          # `|| echo` so the notice never fails the step (and is never the last
+          # command left returning non-zero under bash -e).
+          curl -sS --fail -H "Content-Type: application/json" -d @payload.json "$WEBHOOK_URL" \
+            || echo "::warning::Discord webhook delivery failed - the notification above was NOT sent."
           fi
 
           exit 1

--- a/.github/workflows/tests-nixos.yml
+++ b/.github/workflows/tests-nixos.yml
@@ -130,7 +130,12 @@ jobs:
         run: nix run github:danielefongo/nix-tests -- templates/tests/nixos/test-nixos-wallpapers
 
       - name: Summary and notify on failure
-        if: always()
+        # always() && WEBHOOK_ID: on a fork without secrets the webhook URL is
+        # malformed, so this would curl a broken endpoint on every single run.
+        # continue-on-error: a Discord outage must never turn a passing test
+        # suite into a failed job - the notice is secondary to the result.
+        if: always() && env.WEBHOOK_ID != ''
+        continue-on-error: true
         env:
           WEBHOOK_URL: https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,26 @@ This repo manages multiple NixOS **and** nix-darwin hosts using the [denix](http
 
 Nixpkgs channel: `nixos-26.05`. Home-manager user: `krit`.
 
+## 🏭 CI build workflows - read the doc before touching them
+
+`Documentation/usage/ci/build-workflows.md` is the reference for
+`.github/workflows/build.yml` and `build-darwin.yml`: what they do, the priority
+order of their goals, and - most importantly - **why** each odd-looking decision
+is there, with the incident that caused it.
+
+**Read it before changing, debugging, or reasoning about a build workflow.**
+Several decisions look like bugs and are not: the GC settings differ between
+Linux and Darwin on purpose, `pushed=0` is the normal result of a healthy warm
+run, and `always()` deliberately does not protect the case you probably think it
+does. Every one of those has been re-derived from scratch at least once because
+the reasoning lived only in a commit message.
+
+Treat it as a map, not as gospel - verify against the file before acting, and
+update the doc in the same commit when you invalidate part of it.
+
+`.github/scripts/check-workflow-invariants.py` enforces the subset of this that
+can be checked mechanically; run it after any workflow edit.
+
 ## ⛔ `stateVersion` is NEVER bumped
 
 `system.stateVersion`, `home.stateVersion`, and the `myconfig.constants.homeStateVersion` / `stateVersion` defaults are **frozen at the release each host was first installed under**. Most hosts in this repo are pinned at `"25.11"`. **Do not change these values when bumping nixpkgs channels.** No exceptions, no "I'll just bump it on this one host", no search-and-replace.

--- a/Documentation/usage/cachix/cachix.md
+++ b/Documentation/usage/cachix/cachix.md
@@ -6,6 +6,12 @@ This document explains the "Build Once, Run Everywhere" architecture used in thi
 
 ---
 
+> 🔧 **Looking for how the CI workflows themselves work?** This document covers
+> the strategy. For the machinery - what each job does, why the Nix settings
+> differ per platform, how the three push layers work, and the incident log
+> behind the current design - see
+> [`../ci/build-workflows.md`](../ci/build-workflows.md).
+
 ## 1. The Core Concept: "Factory vs. Warehouse"
 
 In a standard Nix setup, every computer acts as a **Factory**—it downloads source code and compiles it into binaries. This is slow and resource-intensive.

--- a/Documentation/usage/cachix/cachix.md
+++ b/Documentation/usage/cachix/cachix.md
@@ -65,11 +65,15 @@ We define a strict hierarchy of trust and power to optimize resources.
 - **Configuration:** Pull **and** push enabled, same token (`hosts/Krits-MacBook-Pro/default.nix`).
 - **Its factory** is `build-darwin.yml`, not `build.yml` — a separate workflow on a `macos-15` runner. `build.yml` never builds anything for macOS.
 
-### 📦 A second warehouse: `attic`
+### 📦 A note on `attic` — local only, and deliberately not in CI
 
-All three hosts also push to a self-hosted **attic** cache on the NAS
-(`myconfig.attic`, `attic-push` alias). Cachix is the public/offsite warehouse;
-attic is the local one. This document only covers Cachix.
+The hosts also push to a self-hosted **attic** cache on the NAS
+(`myconfig.attic`, `attic-push` alias). It is **not part of the CI workflows and
+must not be added to them**: the NAS is reachable only over Tailscale, and the
+GitHub runners are deliberately not given Tailscale access.
+
+So: attic is a machine-to-machine convenience on the local network. Cachix is the
+only cache CI knows about. Everything below is about Cachix.
 
 ---
 

--- a/Documentation/usage/cachix/cachix.md
+++ b/Documentation/usage/cachix/cachix.md
@@ -2,7 +2,8 @@
 
 This document explains the "Build Once, Run Everywhere" architecture used in this repository. By leveraging **Cachix** and **GitHub Actions**, we ensure that your laptop almost _never_ has to compile code from scratch, saving battery, heat, and time.
 
-- Currently this benefits are only for `x86_64-linux` pc as doing for other architecture would mean keeping an host with that architecture up to date but especially use a lot more cachix space
+- Two architectures are built in the cloud today: **`x86_64-linux`** (both NixOS hosts, in `build.yml`) and **`aarch64-darwin`** (the MacBook, in `build-darwin.yml`, on a GitHub-hosted Apple-silicon runner). Both push to the same `krit-nixos` cache.
+- **`aarch64-linux` is not built.** That is the architecture that would need a machine kept up to date, and a lot more Cachix space.
 
 ---
 
@@ -33,7 +34,8 @@ We define a strict hierarchy of trust and power to optimize resources.
 - **Role:** The Primary Builder.
 - **Trigger:** Automatically runs on every `git push`.
 - **Capabilities:**
-- Builds for **x86_64** (Desktop) natively.
+- Builds **both** `x86_64-linux` hosts natively — `nixos-desktop` *and* `nixos-laptop`, one per runner (`build.yml`).
+- Builds the **`aarch64-darwin`** Mac natively on a `macos-15` runner (`build-darwin.yml`).
 
 - **Why it exists:** To do the heavy lifting while you sleep. It creates the cache entries before you even wake up to update your laptop.
 
@@ -47,15 +49,27 @@ We define a strict hierarchy of trust and power to optimize resources.
 
 - **Why Push is enabled:** If you are developing a new feature locally and haven't pushed to GitHub yet, your Desktop compiles it. By enabling push, your Desktop uploads these new binaries to Cachix. If you then switch to your Laptop, it can download the binaries your Desktop just built, skipping the cloud entirely.
 
-### 🥉 Tier 3: The Laptop (Pure Consumer)
+### 🥉 Tier 3: The Laptop
 
-- **Role:** The Consumer.
+- **Role:** Mostly a consumer, but it *can* push.
 - **Trigger:** Runs when you update (`nh os switch`).
 - **Configuration:**
 - **Pull:** Enabled.
-- **Push:** **DISABLED**.
+- **Push:** **ENABLED** — `hosts/nixos-laptop/default.nix` sets `cachix.push = true` with the same `/run/secrets/cachix-push-token` as the Desktop.
 
-- **Goal:** Zero compilation. If the Laptop starts compiling `webkit` or `gcc`, **something is wrong**. It should only ever download compressed binaries.
+- **Goal:** Still zero compilation in normal use. If the Laptop starts compiling `webkit` or `gcc`, **something is wrong** — but if it does build something, that result is uploaded rather than thrown away.
+
+### 🍎 Tier 3b: The MacBook (`Krits-MacBook-Pro`)
+
+- **Role:** Consumer, with its own cloud builder.
+- **Configuration:** Pull **and** push enabled, same token (`hosts/Krits-MacBook-Pro/default.nix`).
+- **Its factory** is `build-darwin.yml`, not `build.yml` — a separate workflow on a `macos-15` runner. `build.yml` never builds anything for macOS.
+
+### 📦 A second warehouse: `attic`
+
+All three hosts also push to a self-hosted **attic** cache on the NAS
+(`myconfig.attic`, `attic-push` alias). Cachix is the public/offsite warehouse;
+attic is the local one. This document only covers Cachix.
 
 ---
 
@@ -69,7 +83,7 @@ To get the most out of this system, follow this lifecycle for system updates:
 
 - GitHub Actions detects the push and starts the compilation`.
 - It compiles your system and uploads the results to `krit-nixos.cachix.org`.
-- _Duration:_ ~5-15 minutes depending on complexity.
+- _Duration:_ ~15-20 minutes for a **warm** `x86_64-linux` run (run 1110: 12m44s of building, ~20 minutes end to end). A **cold** run — anything that changes `flake.lock`, since the store-cache key includes its hash — is far slower, and the caps are deliberately generous (270-minute build step, 350-minute job).
 
 4. **Update:**
 
@@ -84,25 +98,27 @@ To get the most out of this system, follow this lifecycle for system updates:
 
 This file is the "Robot" that runs the factory.
 
-- **Concurrency:** It cancels old builds if you push new code immediately, saving runner time.
-- **The Cache Loop:** It pulls from Cachix before starting (to speed up its own build) and pushes to Cachix immediately after finishing.
-- **Split Architecture:** It runs separate jobs for x86 and ARM to ensure both architectures are cached simultaneously.
+- **Trigger:** `push` only on **`develop`** and **`main`**, plus **any pull request**, a weekly schedule, and manual dispatch. Pushing a feature branch with no PR open does *not* start a build.
+- **Concurrency:** It cancels older runs of the same workflow on the same ref. ⚠️ This is a genuine trade-off, not a free saving — a cancelled run can lose a long build *and* skip its salvage push. Avoid pushing again while a build you care about is in flight.
+- **The Cache Loop:** It pulls from Cachix before starting, and pushes **continuously during the build** via `cachix watch-exec`, not only at the end. It also pushes when the build *fails*, so a broken package never costs you everything else.
+- **Split by host, not by architecture:** `build.yml` has no ARM job — every job runs on `ubuntu-latest`. Its build matrix splits over the two **x86_64 hosts** (`nixos-desktop`, `nixos-laptop`), one per runner. macOS is a separate workflow entirely.
+
+> 📖 For the full mechanics — the three push layers, why the Nix settings differ per platform, and the incident log behind the current design — see [`../ci/build-workflows.md`](../ci/build-workflows.md).
 
 ### The System Logic (`cachix.nix`)
 
 This file configures your machines to talk to the warehouse.
 
-- **Automatic Auth:** It uses `sops-nix` to securely inject your `CACHIX_AUTH_TOKEN` only on machines allowed to push (the Desktop).
-- **The "Rebuild-Push" Alias:**
-- It creates a shell alias `rebuild-push`.
-- **Function:** Rebuilds your system _and_ uploads the result to Cachix in one go.
-- **Use Case:** Use this on your Desktop when you want to share a build with your Laptop immediately without waiting for GitHub Actions.
+- **Automatic Auth:** `sops-nix` injects the token at `/run/secrets/cachix-push-token`. All three hosts currently enable push and reference it.
+- **Pushing happens automatically on switch.** The rebuild aliases are wrapped (`wrapCaches` in `modules/common/programs/shells/shell-aliases.nix`), so a normal `sw`/switch already pipes `nix path-info -r /run/current-system` into both `attic push` and `cachix push`. Each is suffixed `|| true`, so a cache being unreachable never fails your rebuild.
+- **The manual alias is `cachix-push`** (and `attic-push` for the NAS). There is no `rebuild-push` alias.
+- **Use Case:** run `cachix-push` when you want to share the *current* system closure immediately without waiting for GitHub Actions.
 
 ---
 
 ## 5. Troubleshooting & FAQ
 
-### ❓ Why does the Desktop have "Push" enabled?
+### ❓ Why do the machines have "Push" enabled?
 
 To act as a local cache server. If GitHub is down, or if you are iterating rapidly on a private branch, your Desktop serves as the "Builder" for your Laptop.
 
@@ -120,5 +136,9 @@ If you see your laptop building `firefox`, `gcc`, or `linux-kernel`, **STOP** (C
 
 ### ❓ What if I push to the same branch twice?
 
-The old build will **automatically stop**.
-We use `cancel-in-progress: true` in our workflow. If you push a fix 2 minutes after a previous push, the system kills the old (now obsolete) build to save resources and immediately starts the new one.
+Usually, yes — we use `cancel-in-progress: true`, so pushing a fix kills the now-obsolete build and starts the new one.
+
+⚠️ **Two caveats worth knowing:**
+
+1. It is not instantaneous or perfectly ordered. An older in-progress run has been observed continuing while newer runs in the same group were cancelled and the newest sat `pending` for 20+ minutes. GitHub's queue can be slow — be patient before assuming something is broken.
+2. **Cancelling is not free.** A cancelled run can lose everything it had left to do, including its salvage push to Cachix (observed in run 1115). What it already built is usually safe, because `watch-exec` uploads paths as they are produced — but if a build matters, let it finish.

--- a/Documentation/usage/ci/build-workflows.md
+++ b/Documentation/usage/ci/build-workflows.md
@@ -308,11 +308,23 @@ Guarded by the `push-always` invariant.
 
 This is the important one, and it is not intuitive.
 
-`always()` covers a failed step, a timed-out step, and a cancelled run — for
-cancellation there is a grace window of roughly **eleven minutes** in which
-`always()` steps really do execute (observed in run 1095).
+`always()` covers a failed step and a timed-out step.
 
-It does **not** cover the runner itself dying. There is nothing left to run the
+⚠️ **On cancellation it is not reliable.** Two runs behaved completely
+differently:
+
+- Run 1095 got a grace window of roughly **eleven minutes**, in which `always()`
+  steps really did execute (and `du -sh /nix/store` ate all of it).
+- Run 1115 was cancelled by the concurrency group and its `always()` push step
+  was marked **`skipped`**. The whole job wrapped up in **under one second**.
+  27 minutes of work, no salvage push.
+
+So a cancellation may or may not give you a window. Design for the worst case:
+`watch-exec` is what actually protects a cancelled run, and **avoiding
+unnecessary cancellation matters** — every push to a branch with a run in flight
+discards that run's remaining work.
+
+It also does **not** cover the runner itself dying. There is nothing left to run the
 step. The signature is unmistakable: the job's conclusion is `failure`, the build
 step is still marked `in_progress`, the push step is still marked `pending`, and
 the logs return **HTTP 404** because they were never uploaded.
@@ -370,14 +382,28 @@ what it changed.
 | **1110** | Baseline, desktop only, warm | build **12m44s**, push 9s, cache save 2m36s, job 19m41s |
 | **1111** | Both hosts in one `nix build`. Runner died at 68 min; build step stuck `in_progress`, push step `pending`, logs 404. Nothing pushed, and no notification | One host per runner (matrix); the `report` watchdog job |
 | **1111** (pre-warm) | Confirmed on the wire: `env: CACHIX_TOKEN: ***` then `Neither auth token nor signing key are present.` and exit 1 — reported by GitHub as step `conclusion: success` | `CACHIX_AUTH_TOKEN` set wherever cachix writes; `cachix-auth` invariant |
-| **1115** | Auth fix validated: `outcome=success`, `pushed=0`, notifier silent on all 8 legs | — |
+| **1115** (pre-warm) | Auth fix validated: `outcome=success`, `pushed=0`, notifier silent on all 8 legs | — |
+| **1115** (build) | Cancelled by the concurrency group after 27 min. `always()` push step **skipped**, job over in <1s. Log shows 38 `copying path`, **zero** `building` lines, last output at 11:12 then silence — it was still *evaluating*, with repeated `builtins.derivation … options.json` (IFD) warnings | §6.3 rewritten: `always()` is not reliable on cancellation |
 
 ### The 1111 lesson, stated plainly
 
 Adding `nixos-laptop` to the same `nix build` was justified as "the laptop's
 marginal cost is only its host-specific derivations". Measured, that is false:
-12m44s → died at 68 minutes. With `keep-outputs` retaining every *intermediate*
-output, two closures do not fit in the headroom sized for one.
+12m44s → died at 68 minutes.
+
+⚠️ **The mechanism is not confirmed.** The first hypothesis was disk exhaustion:
+`keep-outputs` retains every *intermediate* output, and the ~78 GiB headroom was
+sized for one closure. Run 1115 does **not** support that. Building the same two
+hosts, it logged 38 substitutions and **zero builds** in 27 minutes, still inside
+evaluation, emitting repeated IFD warnings for `options.json`. Nothing had been
+built, so nothing could have filled the disk.
+
+What is solid: **two hosts in one `nix build` is dramatically more expensive than
+one, and the cost lands before the build phase.** Evaluation is single-threaded
+and holds both configurations in one evaluator process, and IFD serialises it
+further. One host per runner is therefore the right fix either way — it halves
+both the evaluation work and the evaluator's peak memory. Do not write the disk
+explanation back into the code comments until something actually measures it.
 
 ---
 
@@ -461,8 +487,17 @@ things and trusting unsettled ones.
   `building '/nix/store/…'`, not only at the end.
 - 🟠 **Per-host build timings after the matrix split are unmeasured.** Baseline to
   beat is run 1110's 12m44s for the desktop alone. The laptop's true marginal
-  cost is still unknown — run 1111 died before finishing, so the only honest
-  statement is "more than assumed".
+  cost is still unknown — run 1111 died and run 1115 was cancelled, both before
+  finishing, so the only honest statement is "more than assumed".
+- 🟠 **Why two hosts in one `nix build` is so expensive is not established.** Run
+  1115 points at evaluation and IFD rather than disk (§7). Worth an actual
+  measurement — `nix build --print-build-logs` timing of the evaluation phase per
+  host — before anyone theorises again.
+- 🟠 **`cancel-in-progress: true` may be wrong for these workflows.** Run 1115
+  shows a cancellation can discard a long build *and* skip the salvage push. For
+  a workflow whose primary goal is "cache as much as possible", that is a real
+  cost. The alternative (let runs finish) costs runner minutes and queue depth.
+  Not yet decided.
 - 🟠 **Whether `tgt` / `doom` are worth pre-warming is unmeasured.** Both would
   need work to be addressable (§5): `doom` is reachable through the existing
   config tree without touching `flake.nix`, `tgt` would need a single-system

--- a/Documentation/usage/ci/build-workflows.md
+++ b/Documentation/usage/ci/build-workflows.md
@@ -48,7 +48,7 @@ nobody was told**.
 
 | File | What it does | Runner | Job cap |
 |---|---|---|---|
-| `build.yml` | flake check, pre-warm, build both x86_64 hosts, push | `ubuntu-latest` | 120 / 120 / 350 / 10 |
+| `build.yml` | flake check, pre-warm, build both x86_64 hosts, push | `ubuntu-latest` | 120 / 120 / 350 / 10 <br>(`flake-check` / `prewarm-cache` / `build-x86_64` / `report`) |
 | `build-darwin.yml` | flake check + build the Mac config, push | `macos-15` | 350 |
 | `check-workflows.yml` | static analysis of the workflow files themselves | `ubuntu-latest` | 15 |
 | `tests-nixos.yml`, `tests-darwin.yml` | the `templates/tests/` suite | both | 120 / 90 |
@@ -84,7 +84,18 @@ prewarm-cache ──needs──> build-x86_64 (matrix: nixos-desktop, nixos-lapt
 ## 3. How the push actually works
 
 There are **three layers**, and they exist because each one has a hole the next
-one covers.
+one covers. ⚠️ **They are not applied uniformly** — which push step you are
+looking at matters:
+
+| Push step | Layer 1 `watch-exec` | Layer 2 targeted | Layer 3 whole-store |
+|---|---|---|---|
+| `build-x86_64` | ✅ | ✅ gated on build **outcome** + non-empty `outpaths.txt` | ✅ |
+| `prewarm-cache` (per leg) | ✅ | ✅ but gated on `[ -s out.txt ]` **only**, no outcome gate | ✅ |
+| `build-darwin` | ✅ | ❌ **none** — always whole-store | ✅ always |
+| `flake-check` | ❌ | ❌ | ✅ |
+
+Darwin always pushes the whole store on purpose: its job also runs the flake
+check, and a targeted push would miss everything the check built.
 
 ### Layer 1 — `cachix watch-exec` (continuous, during the build)
 
@@ -100,9 +111,10 @@ Two properties to know:
 
 - Nix does **not** fire the hook for *substituted* paths. Only what was genuinely
   built on that runner is uploaded. That is desirable, not a bug.
-- It is probed before use (`cachix watch-exec --help`). If the subcommand is not
-  usable the build runs plain, because a Cachix problem must never be
-  indistinguishable from a broken config.
+- It is probed before use, and the probe is a **three-part conjunction** — the
+  `Set up Cachix` step succeeded, `CACHIX_AUTH_TOKEN` is non-empty, and
+  `cachix watch-exec --help` works. Any one failing drops to a plain build,
+  because a Cachix problem must never be indistinguishable from a broken config.
 
 ### Layer 2 — the targeted push (fast path, clean builds)
 
@@ -113,6 +125,10 @@ Gating on the *outcome* rather than merely on the file being non-empty is
 deliberate: `--keep-going` means the build can fail having realised plenty, and
 `--print-out-paths` prints nothing in that case (the toplevel depends on
 everything), so an emptiness test alone takes neither branch usefully.
+
+**Only `build-x86_64` has this outcome gate.** The pre-warm legs use the
+emptiness test alone (`if [ -s out.txt ]`), which is acceptable there because a
+leg builds a single package rather than a whole system closure.
 
 ### Layer 3 — the whole-store fallback (salvage)
 
@@ -209,8 +225,12 @@ flag (only `nix profile install nixpkgs#cachix` does), so an input flake's own
   `--repair` is load-bearing: plain `--verify` leaves a missing path registered
   whenever something still refers to it, so Nix keeps trusting the db and never
   re-substitutes.
-- `auto-optimise-store` is **off** in CI. The hardlink farm under
-  `/nix/store/.links` does not survive the cache archive round-trip.
+- `auto-optimise-store` is **off on Linux** (`build.yml`), because the hardlink
+  farm under `/nix/store/.links` does not survive the cache archive round-trip
+  and this is the job that *saves* the cache. Darwin turns it **on**
+  (`build-darwin.yml:44`) — it has no store cache to round-trip, so the dedupe is
+  a free disk saving on a machine whose ~40 GiB ceiling is the binding
+  constraint.
 - The save step is **not** `always()`. A cancelled run snapshots a store whose db
   references paths the tar never captured. This is the one deliberate difference
   from the Cachix push, which *is* `always()`: Cachix uploads whole valid paths
@@ -241,10 +261,28 @@ added because run 754 spent its entire 300-minute budget compiling
 `thunderbird-unwrapped`. Adding legs on suspicion costs runner minutes and adds
 notification noise for no proven gain.
 
-⚠️ **Packages from flake inputs cannot be addressed this way.** `tgt`, `concord`
-and `herdr` come from `inputs.<x>.packages.<system>.default`, so they are not
-attributes of `pkgs` and `pkgs.tgt` fails with *attribute missing*. `doom` is not
-a package at all — it is a home-manager module (`programs.doom-emacs`). See §9.
+### 🚨 Do not pre-warm a flake-input package by name
+
+`tgt`, `concord` and `herdr` come from `inputs.<x>.packages.<system>.default`, so
+the derivation the config installs is **not** the `pkgs` attribute of the same
+name. The trap is that two of those attributes *exist anyway* in the pinned
+`nixos-26.05`, and are different software — so `.pkgs.<name>` does not error, it
+silently builds and caches the wrong thing:
+
+| Name | What the config installs | What `pkgs.<name>` is in nixos-26.05 |
+|---|---|---|
+| `tgt` | `github:FedericoBruzzone/tgt` — a Telegram TUI | **tgt 1.0.95, the iSCSI Target daemon** — unrelated |
+| `concord` | `github:chojs23/concord` | **concord 2.3.0, a Discord API library in C** — unrelated |
+| `herdr` | `github:ogulcancelik/herdr` tracking **master** | *absent* from nixos-26.05 — this one does fail cleanly with *attribute missing*. (It exists in `unstable` as 0.8.0, the same project, so this trap appears the moment the channel moves.) |
+
+`concord` is additionally wrapped in `.overrideAttrs` in
+`modules/nixos/programs/concord.nix`, so even the correct input is not the
+derivation the system uses.
+
+`doom` is not a package at all — it is a home-manager module
+(`programs.doom-emacs`, from `nix-doom-emacs-unstraightened`), so it has no
+`pkgs` attribute to name. It *is* reachable through the config tree without
+touching `flake.nix`. See §10.
 
 ---
 
@@ -346,7 +384,10 @@ output, two closures do not fit in the headroom sized for one.
 ## 8. The invariant checker
 
 `.github/scripts/check-workflow-invariants.py`, run by `check-workflows.yml` on
-any change under `.github/workflows/**` or `.github/scripts/**`, plus weekly.
+pushes to `develop`/`main` and on **any pull request** that touches
+`.github/workflows/**` or `.github/scripts/**`, plus weekly (`0 6 * * 1`) and on
+manual dispatch. The `pull_request` trigger has no branch filter, which is why it
+runs on feature branches.
 
 ```bash
 python3 .github/scripts/check-workflow-invariants.py
@@ -383,10 +424,12 @@ whole file as a single argument and break every push.
 - **`[ test ] && cmd` as the last command of a step.** When the test is false the
   list returns non-zero and the step fails. Notifiers therefore append findings
   inside `if` blocks, never with `&&`.
-- **`bash -c` treats bare newlines as separate commands.** A multi-line
-  single-quoted variable handed to `bash -c` runs only its first line — the
-  `BUILD='nix build …'` variable nearly shipped this way, which would have run
-  `nix build` with no arguments. Use backslash continuations. (`bash-c-newline`.)
+- **`bash -c` treats bare newlines as separate commands.** It does not stop after
+  the first line — it executes *every* line as its own command. A multi-line
+  single-quoted `BUILD='nix build …'` variable nearly shipped this way: the first
+  line would have run `nix build` with no arguments, and each following line
+  would then have been run as a command in its own right. Use backslash
+  continuations. (`bash-c-newline`.)
 - **Cross-job step references evaluate to `''` silently.** `steps.<id>.*` for an
   id not declared in the *same* job does not error. (`step-ref`.)
 - **Matrix legs share `run_id` and `run_attempt`.** A cache key that does not

--- a/Documentation/usage/ci/build-workflows.md
+++ b/Documentation/usage/ci/build-workflows.md
@@ -1,0 +1,430 @@
+# 🏭 The CI build workflows
+
+Companion to [`../cachix/cachix.md`](../cachix/cachix.md). That document explains
+the *strategy* — the cloud is the factory, Cachix is the warehouse, your machines
+are customers. This one explains the **machinery**: what the workflow files
+actually do, why each awkward-looking decision is there, and what broke to put it
+there.
+
+---
+
+## ⚠️ How to use this document
+
+**This is a map, not the territory.** The workflow files are the truth; this
+describes them as of the last time someone updated it, and code drifts.
+
+Use it like this: read the relevant section first so you know *why* something is
+the way it is, then **verify against the actual file** before acting. Knowing the
+reason turns a blind search into a targeted one — that is the whole point of the
+document. Nothing here should ever be quoted as authority against the file
+itself.
+
+If you change a workflow in a way that invalidates something below, update it in
+the same commit.
+
+---
+
+## 1. The goal, in priority order
+
+This ordering settles most design arguments. When two properties conflict, the
+higher one wins.
+
+1. **Push to Cachix as much as possibly works — including when the build
+   fails.** A flake bump that breaks one package should still leave every other
+   package cached, so pulling on a PC downloads almost everything and errors only
+   on the broken one. You then fix it on that PC and rebuild.
+2. **Run a flake check, and report problems to Discord.** A flake-check failure
+   must *not* stop the build or the push. Build and push anyway.
+3. **Everything else** — formatting, dead-code notices, package trees, disk
+   reports — must never fail a job.
+
+The failure mode that matters most, therefore, is not "a job went red". It is
+**something was built and did not reach the cache**, or **something failed and
+nobody was told**.
+
+---
+
+## 2. The workflows at a glance
+
+| File | What it does | Runner | Job cap |
+|---|---|---|---|
+| `build.yml` | flake check, pre-warm, build both x86_64 hosts, push | `ubuntu-latest` | 120 / 120 / 350 / 10 |
+| `build-darwin.yml` | flake check + build the Mac config, push | `macos-15` | 350 |
+| `check-workflows.yml` | static analysis of the workflow files themselves | `ubuntu-latest` | 15 |
+| `tests-nixos.yml`, `tests-darwin.yml` | the `templates/tests/` suite | both | 120 / 90 |
+| `update-flake.yml` | weekly `nix flake update` → PR | `ubuntu-latest` | — |
+
+Cache: **`krit-nixos`** (`CACHIX_NAME`, workflow-level env in both build files).
+
+Triggers for the two build workflows are identical: `push` on `develop` and
+`main`, `pull_request` (any branch), `workflow_dispatch`, and `schedule` at
+`0 5 * * 5` (Fridays 05:00 UTC). `update-flake.yml` runs `0 4 * * 5` — an hour
+earlier, so the bump PR exists before the weekly builds.
+
+### `build.yml` job graph
+
+```
+flake-check ─┐
+             │   (independent, runs in parallel)
+prewarm-cache ──needs──> build-x86_64 (matrix: nixos-desktop, nixos-laptop)
+             │                    │
+             └────────────────────┴──needs──> report   (if: always())
+```
+
+- `build-x86_64` has `if: always()` on its `needs`, so a failed or skipped
+  pre-warm leg never blocks the real build. Pre-warming is a pure speedup.
+- `prewarm-cache` is **job-level `continue-on-error: true`**. Its own red status
+  is therefore invisible in the workflow result — which is exactly how a broken
+  push hid there for months (see §7, run 1111). It has its own per-leg notifier
+  for this reason.
+- `report` is a watchdog. See §6.4.
+
+---
+
+## 3. How the push actually works
+
+There are **three layers**, and they exist because each one has a hole the next
+one covers.
+
+### Layer 1 — `cachix watch-exec` (continuous, during the build)
+
+The build command is wrapped in `cachix watch-exec`, which registers a Nix
+**post-build hook**. Every store path is uploaded the moment it finishes
+building, in parallel with the rest of the build.
+
+This is the layer that matters most, because it is the **only one that survives
+the runner dying** (§6.3). If the job is cancelled, times out, or the machine
+disappears, whatever had already been built is already in the cache.
+
+Two properties to know:
+
+- Nix does **not** fire the hook for *substituted* paths. Only what was genuinely
+  built on that runner is uploaded. That is desirable, not a bug.
+- It is probed before use (`cachix watch-exec --help`). If the subcommand is not
+  usable the build runs plain, because a Cachix problem must never be
+  indistinguishable from a broken config.
+
+### Layer 2 — the targeted push (fast path, clean builds)
+
+If the build step's **outcome is `success`** and `outpaths.txt` is non-empty,
+push exactly those paths.
+
+Gating on the *outcome* rather than merely on the file being non-empty is
+deliberate: `--keep-going` means the build can fail having realised plenty, and
+`--print-out-paths` prints nothing in that case (the toplevel depends on
+everything), so an emptiness test alone takes neither branch usefully.
+
+### Layer 3 — the whole-store fallback (salvage)
+
+Any other outcome → `nix path-info --all`, filtered, pushed wholesale.
+
+This is safe because **Cachix's upstream-cache filter is on by default**: paths
+already present in `cache.nixos.org` are skipped. So this uploads what this repo
+produced, not a copy of nixpkgs.
+
+Two filters are applied:
+
+- `.drv` files.
+- `-self-test-` — the Determinate installer writes a path per run whose name
+  carries a timestamp (`self-test-bash-1787097653189`). It is a brand-new store
+  path every single run and nothing ever substitutes it, so left in it grows the
+  cache without bound.
+
+### 🔑 `pushed=0` is normal, not a failure
+
+On a warm run everything substitutes from `cache.nixos.org`, the upstream filter
+skips it all, and the notifier records `pushed=0`. **This is the expected result
+of a healthy warm run.** It is reported as a `note` (⚪) that rides along in a
+message being sent anyway, never as a trigger.
+
+Corollary for debugging: searching a store path on the Cachix website and finding
+nothing does **not** mean pushing is broken. If that path is in
+`cache.nixos.org`, it was correctly skipped. Look for a path that only this repo
+produces (an `activation-krit`, a host toplevel) instead.
+
+---
+
+## 4. The Nix-level configuration, and why it differs per platform
+
+### 🚨 The GC asymmetry — read this before "fixing" it
+
+This is the single most re-litigated decision in the repo. **It is deliberate.**
+
+| | `build.yml` (Linux) | `build-darwin.yml` (macOS) |
+|---|---|---|
+| `min-free` / `max-free` | ❌ absent | ✅ 5 GB / 15 GB |
+| `keep-outputs` / `keep-derivations` | ✅ `true` | ❌ absent |
+| Store cache to protect? | ✅ yes | ❌ no |
+| Free space at start | ~78 GiB (via `nothing-but-nix`) | ~40 GiB, hard ceiling |
+
+**Why Linux keeps and does not collect.** `keep-outputs`/`keep-derivations` stop
+a saved store cache from referencing pruned files — the `user-environment.drv
+does not exist` failure of 2026-07-07. Auto-GC would work against that.
+
+**Why adding auto-GC to Linux would be actively worse.** The build uses
+`--no-link`, so there are **no GC roots**. Auto-GC collects unreferenced paths —
+and with no roots, a just-built toplevel is unreferenced. It could be deleted
+*before the push runs*, which is a worse failure than the disk pressure it would
+relieve. If auto-GC is ever genuinely needed on Linux, `--no-link` has to go
+first so the outputs have roots.
+
+**Why Darwin can afford it.** No store cache to protect, and anything GC removes
+was already uploaded by `watch-exec`, so the worst case is re-substituting from
+our own cache. Run 754 filled the disk (1.4 GiB free, 100% full) and then
+produced nothing for five hours until the step timeout killed it.
+
+**The limit of the reasoning.** The "~78 GiB is plenty" argument was sized for
+**one** system closure. It does not hold for two — see run 1111 in §7.
+
+### Substituters
+
+CI configures the same six extra substituters the machines trust
+(`modules/nixos/toplevel/nix-nixos.nix`): hyprland, cosmic, walker, claude-code,
+vicinae, catppuccin. Darwin gets only claude-code and catppuccin — the rest are
+Linux-only and each extra substituter costs a narinfo round-trip per path.
+
+⚠️ This is **not** covered by `--accept-flake-config`. The builds never pass that
+flag (only `nix profile install nixpkgs#cachix` does), so an input flake's own
+`nixConfig.extra-substituters` is ignored regardless. Without this block CI
+*compiles from source* what every machine simply downloads.
+
+### The store cache (`cache-nix-action`)
+
+- **One saver, two restorers.** Only `build-x86_64` saves; `flake-check` restores
+  only. The two jobs therefore never race on cache writes.
+- **Key shape:**
+  `nix-<os>-<hashFiles(flake.lock)>-<matrix.host>-<run_id>-<run_attempt>`.
+  - The lock hash comes **before** `matrix.host` on purpose, so `flake-check`'s
+    same-lock prefix `nix-<os>-<lock>` still matches. Putting `matrix.host` first
+    silently breaks that — a cache miss is not an error, the job just runs cold
+    forever. Guarded by the `cache-prefix-match` invariant (§8).
+  - `run_id`/`run_attempt` make every attempt save a fresh cache. A key that is
+    only the lock hash can never be updated once it exists, so a first failed
+    attempt would freeze its partial store permanently.
+  - Restoration is **same-lock only**. The old catch-all `nix-<os>-` fallback
+    pulled in stores from arbitrary older runs; `cache-nix-action` *merges* the
+    restored `db.sqlite` into the live one, so stale rows became phantom "valid"
+    entries for paths the archive never carried.
+- `Verify Restored Store` runs `nix-store --verify --repair` at restore time.
+  `--repair` is load-bearing: plain `--verify` leaves a missing path registered
+  whenever something still refers to it, so Nix keeps trusting the db and never
+  re-substitutes.
+- `auto-optimise-store` is **off** in CI. The hardlink farm under
+  `/nix/store/.links` does not survive the cache archive round-trip.
+- The save step is **not** `always()`. A cancelled run snapshots a store whose db
+  references paths the tar never captured. This is the one deliberate difference
+  from the Cachix push, which *is* `always()`: Cachix uploads whole valid paths
+  one at a time, so a truncated push means fewer paths, never a corrupt cache.
+
+---
+
+## 5. The pre-warm matrix
+
+Eight packages, each on its own runner, before the main build:
+
+`vscode`, `obs-studio`, `libreoffice-qt`, `teams-for-linux`, `vesktop`,
+`signal-desktop`, `tor-browser`, `thunderbird`
+
+Built as `.#nixosConfigurations.nixos-desktop.pkgs.<attr>`, **not** plain
+`nixpkgs#<attr>`, so it is the exact derivation the real build would use —
+same overlays, same unfree allowance, same system — not a look-alike from a
+different `pkgs` instantiation.
+
+**What the matrix is for.** Not "making sure these get cached" — the main build
+pushes them anyway. It is for **Hydra-lag windows**: when nixpkgs has bumped
+ahead of Hydra, these large packages have no upstream binary and must be built.
+Doing that on eight parallel runners keeps it out of the build job's budget.
+
+**The bar for adding one is evidence, not intuition.** Every entry is here
+because a log showed it being *built* rather than substituted. `thunderbird` was
+added because run 754 spent its entire 300-minute budget compiling
+`thunderbird-unwrapped`. Adding legs on suspicion costs runner minutes and adds
+notification noise for no proven gain.
+
+⚠️ **Packages from flake inputs cannot be addressed this way.** `tgt`, `concord`
+and `herdr` come from `inputs.<x>.packages.<system>.default`, so they are not
+attributes of `pkgs` and `pkgs.tgt` fails with *attribute missing*. `doom` is not
+a package at all — it is a home-manager module (`programs.doom-emacs`). See §9.
+
+---
+
+## 6. Failure semantics — the four hard-won rules
+
+### 6.1 `continue-on-error` makes a failed step report success
+
+A step with `continue-on-error: true` has `conclusion == 'success'` **even when
+it failed**. Only `outcome` holds the truth, and only a later step can read it
+via `steps.<id>.outcome`.
+
+This is how the pre-warm push failed on every leg of every run for months while
+the job stayed green. Any check written against `.conclusion` on such a step is
+dead code. Guarded by the `outcome-not-conclusion` invariant.
+
+### 6.2 A step with no status function is skipped once the job has failed
+
+Every push step is `if: always() && ...`. Without `always()` the push is skipped
+precisely when the build failed — which is when there is the most to salvage.
+Guarded by the `push-always` invariant.
+
+### 6.3 `always()` does **not** survive the runner dying
+
+This is the important one, and it is not intuitive.
+
+`always()` covers a failed step, a timed-out step, and a cancelled run — for
+cancellation there is a grace window of roughly **eleven minutes** in which
+`always()` steps really do execute (observed in run 1095).
+
+It does **not** cover the runner itself dying. There is nothing left to run the
+step. The signature is unmistakable: the job's conclusion is `failure`, the build
+step is still marked `in_progress`, the push step is still marked `pending`, and
+the logs return **HTTP 404** because they were never uploaded.
+
+Two consequences:
+
+- `watch-exec` (§3, layer 1) is not a nice extra. It is the **only** protection
+  against this case.
+- Keeping each job inside a resource envelope a runner survives is a
+  **push-reliability measure**, not a performance tweak. That is why the two
+  x86_64 hosts build on separate runners.
+
+### 6.4 A dying runner cannot notify you about itself
+
+Every in-job notifier lives inside the job it reports on, so the worst failure
+the workflow can suffer was also the only one that was silent.
+
+The `report` job exists for this. It runs on its **own runner**, `needs` the
+other three, is `if: always()`, and reads `needs.<job>.result` — which GitHub
+fills in however the job ended. It stays quiet when every job reached a normal
+end, so a green run is still silent.
+
+### Ordering inside a job
+
+Nothing that merely prints information may run before the steps that persist
+something. Order is: **push → save cache → disk → package tree → notify.**
+
+`du -sh /nix/store` is banned before the push: it walks the whole store, took
+over ten minutes on a 32 GB store in run 1095, and burned the entire grace window
+before being SIGTERM'd (exit 143). `df -h /nix` reports the same actionable
+number instantly. Guarded by the `grace-window` invariant.
+
+### What gates the push
+
+Push steps are gated on `steps.cachix_setup.outcome == 'success'`. That step
+installs the cachix CLI **and** runs `cachix use`. `cachix use` configures a
+*substituter* — it is about downloading and has nothing to do with pushing — so
+it is deliberately **non-fatal** and only warns. Making it fatal means a
+transient substituter-config hiccup silently disables all pushing with a
+perfectly valid token.
+
+---
+
+## 7. Incident log
+
+The cheapest way to avoid re-deriving all of this. Each entry: what happened →
+what it changed.
+
+| Run / date | What happened | Outcome |
+|---|---|---|
+| 2026-07-07 | `user-environment.drv does not exist` on a restored cache — db rows pointing at files the archive never carried | `keep-outputs`/`keep-derivations`; `nix-store --verify --repair` at restore; same-lock-only restore prefixes |
+| 2026-07-08 | `Error: not found: cachix` failed a whole job | Pushing is `continue-on-error` everywhere — a Cachix outage must never fail a build |
+| **754** (darwin) | Built `thunderbird-unwrapped-153.0.1` in a Hydra-lag window, filled the disk (1.4 GiB free, 100%), then produced nothing for five hours until the step timeout | Darwin auto-GC (`min-free`/`max-free`); `thunderbird` added to the pre-warm matrix |
+| **1095** | `du -sh /nix/store` consumed the whole ~11-minute cancellation grace window, SIGTERM exit 143, push never ran. Same run showed `vicinae-0.25.0` compiled from source despite vicinae publishing a cachix | `df` instead of `du`; the six extra substituters added to CI |
+| **1110** | Baseline, desktop only, warm | build **12m44s**, push 9s, cache save 2m36s, job 19m41s |
+| **1111** | Both hosts in one `nix build`. Runner died at 68 min; build step stuck `in_progress`, push step `pending`, logs 404. Nothing pushed, and no notification | One host per runner (matrix); the `report` watchdog job |
+| **1111** (pre-warm) | Confirmed on the wire: `env: CACHIX_TOKEN: ***` then `Neither auth token nor signing key are present.` and exit 1 — reported by GitHub as step `conclusion: success` | `CACHIX_AUTH_TOKEN` set wherever cachix writes; `cachix-auth` invariant |
+| **1115** | Auth fix validated: `outcome=success`, `pushed=0`, notifier silent on all 8 legs | — |
+
+### The 1111 lesson, stated plainly
+
+Adding `nixos-laptop` to the same `nix build` was justified as "the laptop's
+marginal cost is only its host-specific derivations". Measured, that is false:
+12m44s → died at 68 minutes. With `keep-outputs` retaining every *intermediate*
+output, two closures do not fit in the headroom sized for one.
+
+---
+
+## 8. The invariant checker
+
+`.github/scripts/check-workflow-invariants.py`, run by `check-workflows.yml` on
+any change under `.github/workflows/**` or `.github/scripts/**`, plus weekly.
+
+```bash
+python3 .github/scripts/check-workflow-invariants.py
+```
+
+**Every invariant is a bug that actually happened here**, tagged with the run
+that exposed it. It is deliberately *not* a general-purpose linter — actionlint
+covers that. It protects the one property a generic tool cannot know about: what
+gets built must reach the cache, and failures must not be silent.
+
+Current checks: `cachix-auth`, `push-always`, `push-non-fatal`, `step-ref`,
+`outcome-not-conclusion`, `pipefail`, `bash-c-newline`, `grace-window`,
+`matrix-cache-key`, `notify-guard`, `notify-non-fatal`, `webhook-curl-fail`,
+`cache-prefix-match`.
+
+**If you add a check, mutation-test it** — reintroduce the bug in a temp copy and
+confirm the checker fails. A check that cannot fail is worse than no check,
+because it reads as coverage.
+
+`actionlint` runs alongside it, gated on its own analysis with **shellcheck
+advisory only**. Several shellcheck findings here are deliberate:
+`cachix push <cache> $(cat out.txt)` relies on word splitting to turn one path
+per line into one argument per path, and quoting it as SC2046 asks would pass the
+whole file as a single argument and break every push.
+
+---
+
+## 9. Shell and Actions gotchas that have bitten this repo
+
+- **`bash -e` without `-o pipefail`.** GitHub runs `run:` blocks with `bash -e`
+  only. A pipe into `tee` or `cachix` reports the *last* command's status, so an
+  upstream failure is masked and the step reports success having done nothing.
+  Add `set -o pipefail` in any step that pipes. (`pipefail` invariant.)
+- **`[ test ] && cmd` as the last command of a step.** When the test is false the
+  list returns non-zero and the step fails. Notifiers therefore append findings
+  inside `if` blocks, never with `&&`.
+- **`bash -c` treats bare newlines as separate commands.** A multi-line
+  single-quoted variable handed to `bash -c` runs only its first line — the
+  `BUILD='nix build …'` variable nearly shipped this way, which would have run
+  `nix build` with no arguments. Use backslash continuations. (`bash-c-newline`.)
+- **Cross-job step references evaluate to `''` silently.** `steps.<id>.*` for an
+  id not declared in the *same* job does not error. (`step-ref`.)
+- **Matrix legs share `run_id` and `run_attempt`.** A cache key that does not
+  name the matrix variable collides between legs of the same run.
+  (`matrix-cache-key`.)
+- **`curl -s` exits 0 on HTTP 4xx/5xx.** A rotated webhook token looks exactly
+  like a delivered notification. Use `--fail`. (`webhook-curl-fail`.)
+- **`grep -c` exits 1 on zero matches** under `-e`; the `|| true` on the
+  `pushed=` lines is load-bearing.
+- **GitHub's queue.** Runs can sit `pending` for 20+ minutes. Observed: an older
+  in-progress run continuing while newer runs in the same concurrency group were
+  cancelled, and the newest held `pending` until the old one ended. Be patient
+  before concluding something is broken.
+
+---
+
+## 10. Open questions and things not yet verified
+
+Keep this section honest — it is what stops the next person re-testing settled
+things and trusting unsettled ones.
+
+- 🔴 **`watch-exec` has never been observed uploading mid-build.** It is
+  confirmed to *engage* (`Building under 'cachix watch-exec'`, run 768), but
+  every run so far has been warm, so there has been nothing to upload. Since it
+  is the only protection against runner death (§6.3), this is the most valuable
+  thing left to confirm. It needs a **cold** run — a flake bump changes
+  `flake.lock`, which changes the store-cache key, which misses the cache
+  entirely. Look for `Pushing /nix/store/…` interleaved with
+  `building '/nix/store/…'`, not only at the end.
+- 🟠 **Per-host build timings after the matrix split are unmeasured.** Baseline to
+  beat is run 1110's 12m44s for the desktop alone. The laptop's true marginal
+  cost is still unknown — run 1111 died before finishing, so the only honest
+  statement is "more than assumed".
+- 🟠 **Whether `tgt` / `doom` are worth pre-warming is unmeasured.** Both would
+  need work to be addressable (§5): `doom` is reachable through the existing
+  config tree without touching `flake.nix`, `tgt` would need a single-system
+  `packages` output. Do not add either until a log shows it being *built* rather
+  than substituted. A general `packages` output re-exporting flake inputs is a
+  bad idea: `concord` is used via `.overrideAttrs`, so a plain re-export is a
+  *different derivation* and pre-warming it would cache a path the build never
+  substitutes.

--- a/Documentation/usage/ci/build-workflows.md
+++ b/Documentation/usage/ci/build-workflows.md
@@ -472,6 +472,23 @@ whole file as a single argument and break every push.
 
 ---
 
+## 10. ⚠️ Things only a human can do
+
+Automation cannot resolve these. If one is blocking, it needs the repo owner.
+
+| Situation | Why automation cannot | What the owner needs to do |
+|---|---|---|
+| Cancelling a workflow run | The session token has no `actions: write`; `POST /actions/runs/:id/cancel` returns **403**. | Cancel from the Actions tab. |
+| Rotating `CACHIX_AUTH_TOKEN` or the Discord webhook secrets | Repository secrets are write-only to CI and unreadable from a session. | Update under Settings → Secrets. |
+| Cachix storage running out | The cache's quota is an account-level setting. | Raise the plan, or `cachix gc`. |
+| Giving CI access to the NAS / `attic` | The NAS is Tailscale-only and CI is deliberately not on the tailnet — see the note in the cachix doc. **This is a decision, not a gap. Do not "fix" it.** | Nothing — it is intentional. |
+| Merging to `main` | `develop` is the integration branch; promotion to `main` is a human call. | Merge when satisfied. |
+| Approving a flake-update PR | A dependency bump is a judgement call about what the machines will run. | Review and merge. |
+
+**Anything an automated session cannot finish should be recorded here rather than
+left in a chat message**, because chat scrollback is not something a future
+session can rely on reading.
+
 ## 10. Open questions and things not yet verified
 
 Keep this section honest — it is what stops the next person re-testing settled


### PR DESCRIPTION
Started as "also build `nixos-laptop`". That change turned out to break the build outright, and fixing it surfaced a family of silent failures. The scope is now: **whatever CI manages to build must reach the cache, and a failure must never be silent.**

> ⚠️ The original description of this PR is obsolete. It proposed building both x86_64 hosts in **one** `nix build`, on the reasoning that the laptop's marginal cost was only its host-specific derivations. Measurement disproved that — see below.

## What went wrong, measured

| run | hosts | build step | outcome |
|---|---|---|---|
| 1110 | desktop only | **12m44s** | ✅ pushed, job 19m41s |
| 1111 | desktop **+ laptop**, one build | 68 min, never finished | ❌ runner died — build step stuck `in_progress`, push step `pending`, logs HTTP 404, **nothing pushed and nobody notified** |
| 1115 | desktop **+ laptop**, one build | 27 min, cancelled | ❌ 38 substitutions, **zero** builds, still evaluating; `always()` push step **skipped** |

So the two-host build never even reached the build phase, and both failure modes lost the push entirely.

## Fixes

**One host per runner.** A `matrix.host` over `nixos-desktop` / `nixos-laptop`, `fail-fast: false`. Restores the envelope run 1110 survived, gives the hosts independent failure domains, and makes wall-clock `max()` rather than the sum. `matrix.host` is part of the store-cache key — without it both legs of a run compute the same key (`run_id`/`run_attempt` are shared) and one leg's store is lost.

**`cachix use` no longer gates pushing.** Every push was gated on a step that runs both `nix profile install cachix` *and* `cachix use`. The latter configures a *substituter* — downloading, not uploading — so a transient hiccup there silently disabled all pushing with a valid token. Now non-fatal.

**`CACHIX_AUTH_TOKEN` where cachix writes.** The pre-warm push set only `CACHIX_TOKEN`. Confirmed on the wire in run 1111:

```
env:
  CACHIX_TOKEN: ***
Neither auth token nor signing key are present.
##[error]Process completed with exit code 1
```

GitHub reported that step as `conclusion: success`, because `continue-on-error` masks it. Every leg, every run, for months. Validated fixed in run 1115.

**A watchdog that survives a dead runner.** Every notifier lived inside the job it reported on, so the worst failure was the only silent one. A `report` job now runs on its own runner and reads `needs.<job>.result`.

**`curl --fail` on all 7 webhook calls** — without it curl exits 0 on HTTP 4xx/5xx, so a revoked token looked exactly like a delivered message.

**Cache-prefix regression, caught by the new linter**: putting `matrix.host` before the lock hash meant `flake-check`'s `nix-<os>-<lock>` prefix could never match again — it would have run cold forever, silently, since a cache miss is not an error.

## A check so this class of bug cannot come back

`.github/workflows/check-workflows.yml` + `.github/scripts/check-workflow-invariants.py` — **117 invariants**, every one a bug that actually happened here, tagged with the run that exposed it: `cachix-auth`, `push-always`, `push-non-fatal`, `step-ref`, `outcome-not-conclusion`, `pipefail`, `bash-c-newline`, `grace-window`, `matrix-cache-key`, `notify-guard`, `notify-non-fatal`, `webhook-curl-fail`, `cache-prefix-match`.

Every invariant is **mutation-tested** — the bug is reintroduced in a temp copy and the checker must fail. A check that cannot fail reads as coverage without being coverage.

Paired with `actionlint`, gated on its own analysis with shellcheck **advisory only**: `cachix push <cache> $(cat out.txt)` relies on word splitting to turn one path per line into one argument per path, and quoting it as SC2046 asks would break every push.

Runs on pushes to `develop`/`main`, on any PR touching `.github/workflows/**` or `.github/scripts/**`, weekly, and on dispatch. Green on its first CI run.

## Documentation

`Documentation/usage/ci/build-workflows.md` — the reasoning lived only in commit messages and kept being re-derived. Covers the goal priority order, the three push layers, the **deliberate** Linux/Darwin GC asymmetry, the failure-semantics rules, an incident log keyed by run number, and an explicit open-questions section. Fact-checked by parallel verifiers against the code; one claim was outright wrong (`pkgs.tgt` and `pkgs.concord` **do** exist in nixos-26.05 as unrelated software, so pre-warming them by name would silently cache the wrong derivation rather than error).

`Documentation/usage/cachix/cachix.md` corrected too — it claimed the cache "only benefits x86_64-linux" *and* that build.yml "runs separate jobs for x86 and ARM" (neither true, and mutually contradictory), described the laptop as push-disabled (all three hosts push), omitted the Mac, and documented a `rebuild-push` alias that does not exist.

Linked from `CLAUDE.md`, which loads automatically — that is the part that actually prevents the context loss.

## Known-unverified

`cachix watch-exec` uploading **during** a build has still never been observed — every run so far was warm. Since `always()` protects neither a dead runner nor (per run 1115) a cancellation, watch-exec is the only real protection, so this is the most valuable thing left to confirm. It needs a cold run, which a flake bump produces.