### PR TITLE
ci: bound the timeout budget, and make shellcheck a signal instead of noise

### DIFF
--- a/.github/workflows/build-darwin.yml
+++ b/.github/workflows/build-darwin.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: macos-15
     # Stay below GitHub's hard 360-minute job kill so the cachix daemon's
     # final flush still runs on a slow build.
-    timeout-minutes: 350
+    timeout-minutes: 180
     permissions:
       contents: read
       id-token: write
@@ -135,7 +135,7 @@ jobs:
       # branch of the graph, so one bad package doesn't cost us the closure.
       - name: Build Darwin Configuration
         id: build
-        timeout-minutes: 300
+        timeout-minutes: 150
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
@@ -253,7 +253,10 @@ jobs:
         continue-on-error: true
         run: |
           if [ -s outpaths.txt ]; then
-            nix path-info -sh -r $(cat outpaths.txt)
+            # shellcheck disable=SC2046  # word splitting is REQUIRED here:
+          # one store path per line must become one argument per path.
+          # Quoting would pass the whole file as a single argument.
+          nix path-info -sh -r $(cat outpaths.txt)
           else
             echo "No output paths were built."
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
           # so a broken third-party apt repo (packages.microsoft.com,
           # dl.google.com, ...) must never fail the job. Worst case we keep
           # the image's cert bundle - exactly what we'd have without this step.
+          # shellcheck disable=SC2046  # word splitting is REQUIRED here:
+          # grep -l can list several files and each must be its own argument.
           sudo rm -f $(grep -lr packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null) || true
           sudo apt-get update || true
           sudo apt-get install -y ca-certificates || true
@@ -229,13 +231,18 @@ jobs:
         continue-on-error: true
         run: |
           NO_COLOR=1 nix run --inputs-from . nixpkgs#deadnix -- . > deadnix_report.txt || true
+          # Quoted, and grouped into one redirect: every other GITHUB_OUTPUT /
+          # GITHUB_ENV write in these workflows quotes the path, and this was the
+          # only place that did not.
           if [ -s deadnix_report.txt ]; then
-            echo "HAS_DEAD_CODE=true" >> $GITHUB_ENV
-            echo "DEADCODE_REPORT<<EOF" >> $GITHUB_ENV
-            head -n 20 deadnix_report.txt >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
+            {
+              echo "HAS_DEAD_CODE=true"
+              echo "DEADCODE_REPORT<<EOF"
+              head -n 20 deadnix_report.txt
+              echo "EOF"
+            } >> "$GITHUB_ENV"
           else
-            echo "HAS_DEAD_CODE=false" >> $GITHUB_ENV
+            echo "HAS_DEAD_CODE=false" >> "$GITHUB_ENV"
           fi
 
 
@@ -340,11 +347,15 @@ jobs:
   # rebuilds inside build-x86_64 as before.
   prewarm-cache:
     runs-on: ubuntu-latest
-    # 120 rather than 60: a leg killed by the job timeout used to push nothing,
-    # so a package that needed 70 minutes never got cached and every later run
-    # paid for it again. It now pushes continuously (see below), but the extra
-    # headroom lets the slow legs actually finish.
-    timeout-minutes: 120
+    # prewarm-cache runs BEFORE build-x86_64 (needs:), so its cap adds to the
+    # build's on the critical path. 60 + 180 keeps the whole serial chain under
+    # four hours, comfortably clear of the ~300-minute mark and of GitHub's
+    # 360-minute hard kill.
+    #
+    # A leg that hits this cap is not wasted: watch-exec has already uploaded
+    # everything it built, so the next run starts further along. That is exactly
+    # the property that lets the cap be tight.
+    timeout-minutes: 60
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -423,10 +434,10 @@ jobs:
       # place. The end-of-step push below stays as a backstop.
       - name: Pre-warm ${{ matrix.attr }}
         id: prewarm
-        # 100 not 110: leaves a ~20-minute tail inside the 120-minute job
-        # cap for the backstop push.
+        # 45 leaves a ~15-minute tail inside the 60-minute job cap for the
+        # backstop push.
         continue-on-error: true
-        timeout-minutes: 100
+        timeout-minutes: 45
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
@@ -472,6 +483,9 @@ jobs:
           fi
 
           if [ -s out.txt ]; then
+          # shellcheck disable=SC2046  # word splitting is REQUIRED here:
+            # one store path per line must become one argument per path.
+            # Quoting would pass the whole file as a single argument.
             cachix push ${{ env.CACHIX_NAME }} $(cat out.txt) 2>&1 | tee push.log
             echo "pushed=$(grep -c '^Pushing ' push.log || true)" >> "$GITHUB_OUTPUT"
             exit 0
@@ -587,10 +601,16 @@ jobs:
         host:
           - nixos-desktop
           - nixos-laptop
-    # Stay below GitHub's hard 360-minute job kill: a hard-killed job loses
-    # its cache-save and cachix-flush steps, which is why retries used to
-    # restart from zero.
-    timeout-minutes: 350
+    # Capped well under the ~300-minute mark on purpose. A cold run (any
+    # flake.lock bump misses the store cache entirely) could otherwise approach
+    # GitHub's 360-minute hard kill, and a hard kill loses the cache-save step.
+    #
+    # Truncation is NOT data loss here, which is what makes a tight cap safe:
+    # cachix watch-exec has already uploaded every path as it was built, and the
+    # store cache still saves on a timeout, so the next run resumes further along
+    # the dependency chain. Progress is monotonic across runs - two bounded runs
+    # beat one five-hour run that risks the hard kill.
+    timeout-minutes: 180
     permissions:
       contents: read
       id-token: write
@@ -609,6 +629,8 @@ jobs:
           # so a broken third-party apt repo (packages.microsoft.com,
           # dl.google.com, ...) must never fail the job. Worst case we keep
           # the image's cert bundle - exactly what we'd have without this step.
+          # shellcheck disable=SC2046  # word splitting is REQUIRED here:
+          # grep -l can list several files and each must be its own argument.
           sudo rm -f $(grep -lr packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null) || true
           sudo apt-get update || true
           sudo apt-get install -y ca-certificates || true
@@ -762,7 +784,9 @@ jobs:
       # single `nix build` killed the runner and cost us the push entirely.
       - name: Build ${{ matrix.host }}
         id: build
-        timeout-minutes: 270
+        # Leaves a ~30-minute tail inside the 180-minute job cap for the push,
+        # the cache save and the notifier.
+        timeout-minutes: 150
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
@@ -836,6 +860,9 @@ jobs:
           # targeted fast path means ANY failure falls through to the
           # whole-store push, which is what actually salvages partial work.
           if [ "${{ steps.build.outcome }}" = "success" ] && [ -s outpaths.txt ]; then
+          # shellcheck disable=SC2046  # word splitting is REQUIRED here:
+            # one store path per line must become one argument per path.
+            # Quoting would pass the whole file as a single argument.
             cachix push ${{ env.CACHIX_NAME }} $(cat outpaths.txt) 2>&1 | tee push.log
             echo "pushed=$(grep -c '^Pushing ' push.log || true)" >> "$GITHUB_OUTPUT"
             exit 0
@@ -927,7 +954,10 @@ jobs:
         continue-on-error: true
         run: |
           if [ -s outpaths.txt ]; then
-            nix path-info -sh -r $(cat outpaths.txt)
+            # shellcheck disable=SC2046  # word splitting is REQUIRED here:
+          # one store path per line must become one argument per path.
+          # Quoting would pass the whole file as a single argument.
+          nix path-info -sh -r $(cat outpaths.txt)
           else
             echo "No output paths were built."
           fi

--- a/Documentation/usage/cachix/cachix.md
+++ b/Documentation/usage/cachix/cachix.md
@@ -87,7 +87,7 @@ To get the most out of this system, follow this lifecycle for system updates:
 
 - GitHub Actions detects the push — on `develop`/`main`, or on any branch with a PR open — and starts the compilation.
 - It compiles your system and uploads the results to `krit-nixos.cachix.org`.
-- _Duration:_ ~15-20 minutes for a **warm** `x86_64-linux` run (run 1110: 12m44s of building, ~20 minutes end to end). A **cold** run — anything that changes `flake.lock`, since the store-cache key includes its hash — is far slower, and the caps are deliberately generous (270-minute build step, 350-minute job).
+- _Duration:_ ~15-20 minutes for a **warm** `x86_64-linux` run (run 1110: 12m44s of building, ~20 minutes end to end). A **cold** run — anything that changes `flake.lock`, since the store-cache key includes its hash — is far slower. Caps are bounded rather than generous (150-minute build step, 180-minute job), because a timeout is not data loss here: `watch-exec` has already uploaded whatever was built, so the next run resumes further along.
 
 4. **Update:**
 

--- a/Documentation/usage/cachix/cachix.md
+++ b/Documentation/usage/cachix/cachix.md
@@ -32,7 +32,7 @@ We define a strict hierarchy of trust and power to optimize resources.
 ### 🥇 Tier 1: The Cloud (GitHub Actions)
 
 - **Role:** The Primary Builder.
-- **Trigger:** Automatically runs on every `git push`.
+- **Trigger:** `push` on **`develop`** and **`main`**, any **pull request**, a weekly **schedule** (`0 5 * * 5`, Fridays 05:00 UTC), and manual **`workflow_dispatch`**. Pushing a feature branch with no PR open does *not* start a build.
 - **Capabilities:**
 - Builds **both** `x86_64-linux` hosts natively — `nixos-desktop` *and* `nixos-laptop`, one per runner (`build.yml`).
 - Builds the **`aarch64-darwin`** Mac natively on a `macos-15` runner (`build-darwin.yml`).
@@ -85,7 +85,7 @@ To get the most out of this system, follow this lifecycle for system updates:
 2. **Push:** You run `git push`.
 3. **The "Coffee Break" (Wait):**
 
-- GitHub Actions detects the push and starts the compilation`.
+- GitHub Actions detects the push — on `develop`/`main`, or on any branch with a PR open — and starts the compilation.
 - It compiles your system and uploads the results to `krit-nixos.cachix.org`.
 - _Duration:_ ~15-20 minutes for a **warm** `x86_64-linux` run (run 1110: 12m44s of building, ~20 minutes end to end). A **cold** run — anything that changes `flake.lock`, since the store-cache key includes its hash — is far slower, and the caps are deliberately generous (270-minute build step, 350-minute job).
 

--- a/Documentation/usage/ci/build-workflows.md
+++ b/Documentation/usage/ci/build-workflows.md
@@ -432,6 +432,20 @@ what it changed.
 | **761** (darwin, on `main`) | Build step hit its own `timeout-minutes: 300` at 300.23 min and failed. The job then ran post-steps normally for 3.3 min — GitHub did not kill it. **`Push to Cachix` was `skipped`**, because `main`'s gate is `if: steps.build.outcome == 'success'` with no `always()`. Five hours of building, nothing cached | The `always()` push gate, fixed on `develop`. `main` still has the old gate |
 | **1115** (build) | Cancelled by the concurrency group after 27 min. `always()` push step **skipped**, job over in <1s. Log shows 38 `copying path`, **zero** `building` lines, last output at 11:12 then silence — it was still *evaluating*, with repeated `builtins.derivation … options.json` (IFD) warnings | §6.3 rewritten: `always()` is not reliable on cancellation |
 
+### `main` lags `develop` on purpose
+
+`main` still carries the pre-fix workflows — `build-darwin.yml` caps of 300/350
+and a push gated on `steps.build.outcome == 'success'` with no `always()`, the
+combination that lost five hours in run 761.
+
+**This is known and accepted, not a gap to fix.** `develop` is where the
+workflows are stabilised; the owner promotes to `main` by hand once satisfied,
+and that single merge brings every fix across at once. No Nix code is being
+changed on `main` in the meantime, so the stale workflows there are not building
+anything that matters.
+
+Do not "helpfully" open a PR against `main` to sync it.
+
 ### The 1111 lesson, stated plainly
 
 Adding `nixos-laptop` to the same `nix build` was justified as "the laptop's
@@ -529,7 +543,7 @@ Automation cannot resolve these. If one is blocking, it needs the repo owner.
 | Rotating `CACHIX_AUTH_TOKEN` or the Discord webhook secrets | Repository secrets are write-only to CI and unreadable from a session. | Update under Settings → Secrets. |
 | Cachix storage running out | The cache's quota is an account-level setting. | Raise the plan, or `cachix gc`. |
 | Giving CI access to the NAS / `attic` | The NAS is Tailscale-only and CI is deliberately not on the tailnet — see the note in the cachix doc. **This is a decision, not a gap. Do not "fix" it.** | Nothing — it is intentional. |
-| Merging to `main` | `develop` is the integration branch; promotion to `main` is a human call. | Merge when satisfied. **`main` currently still has every pre-fix bug**: `build-darwin.yml` caps of 300/350 and a push gated on `steps.build.outcome == 'success'` with no `always()` — the exact combination that threw away five hours of run 761. Until `develop` is promoted, any build running from `main` can still lose everything it built. |
+| Merging to `main` | `develop` is the integration branch; promotion to `main` is a human call. | Merge when satisfied. |
 | Approving a flake-update PR | A dependency bump is a judgement call about what the machines will run. | Review and merge. |
 
 **Anything an automated session cannot finish should be recorded here rather than

--- a/Documentation/usage/ci/build-workflows.md
+++ b/Documentation/usage/ci/build-workflows.md
@@ -546,6 +546,8 @@ Automation cannot resolve these. If one is blocking, it needs the repo owner.
 | Situation | Why automation cannot | What the owner needs to do |
 |---|---|---|
 | Cancelling a workflow run | The session token has no `actions: write`; `POST /actions/runs/:id/cancel` returns **403**. | Cancel from the Actions tab. |
+| **Triggering any `workflow_dispatch`** | Same missing permission: `POST /actions/workflows/:id/dispatches` returns **403**. An automated session cannot start `update-flake.yml`, nor manually dispatch `build.yml` / `build-darwin.yml` against a branch. | Actions tab → pick the workflow → **Run workflow**. |
+| Producing a `flake.lock` bump by hand | There is no Nix in the session container, so `nix flake update` cannot be run locally either. Combined with the row above, a flake bump is entirely owner-or-schedule driven. | Run **Update Flake Lockfile** from the Actions tab, or wait for the Friday 04:00 UTC cron. |
 | Rotating `CACHIX_AUTH_TOKEN` or the Discord webhook secrets | Repository secrets are write-only to CI and unreadable from a session. | Update under Settings → Secrets. |
 | Cachix storage running out | The cache's quota is an account-level setting. | Raise the plan, or `cachix gc`. |
 | Giving CI access to the NAS / `attic` | The NAS is Tailscale-only and CI is deliberately not on the tailnet — see the note in the cachix doc. **This is a decision, not a gap. Do not "fix" it.** | Nothing — it is intentional. |

--- a/Documentation/usage/ci/build-workflows.md
+++ b/Documentation/usage/ci/build-workflows.md
@@ -48,8 +48,8 @@ nobody was told**.
 
 | File | What it does | Runner | Job cap |
 |---|---|---|---|
-| `build.yml` | flake check, pre-warm, build both x86_64 hosts, push | `ubuntu-latest` | 120 / 120 / 350 / 10 <br>(`flake-check` / `prewarm-cache` / `build-x86_64` / `report`) |
-| `build-darwin.yml` | flake check + build the Mac config, push | `macos-15` | 350 |
+| `build.yml` | flake check, pre-warm, build both x86_64 hosts, push | `ubuntu-latest` | 120 / 60 / 180 / 10 <br>(`flake-check` / `prewarm-cache` / `build-x86_64` / `report`) |
+| `build-darwin.yml` | flake check + build the Mac config, push | `macos-15` | 180 |
 | `check-workflows.yml` | static analysis of the workflow files themselves | `ubuntu-latest` | 15 |
 | `tests-nixos.yml`, `tests-darwin.yml` | the `templates/tests/` suite | both | 120 / 90 |
 | `update-flake.yml` | weekly `nix flake update` → PR | `ubuntu-latest` | — |
@@ -78,6 +78,33 @@ prewarm-cache ──needs──> build-x86_64 (matrix: nixos-desktop, nixos-lapt
   push hid there for months (see §7, run 1111). It has its own per-leg notifier
   for this reason.
 - `report` is a watchdog. See §6.4.
+
+### ⏱️ Timeout budget
+
+Every cap is deliberately well under GitHub's 360-minute hard kill, and the
+**serial** chain is what matters: `prewarm-cache` (60) runs before
+`build-x86_64` (180) via `needs:`, so the critical path is **240 minutes**, not
+the sum of every job.
+
+| | job cap | build-step cap |
+|---|---|---|
+| `flake-check` | 120 | — |
+| `prewarm-cache` | 60 | 45 per leg |
+| `build-x86_64` | 180 | 150 |
+| `report` | 10 | — |
+| `build-darwin` | 180 | 150 |
+
+Each build-step cap leaves a tail inside its job cap for the push, the cache save
+and the notifier.
+
+**A tight cap is safe here, and that is not obvious.** Hitting a timeout is not
+data loss: `watch-exec` has already uploaded every path as it was built, and the
+store cache still saves on a timeout (the save step runs on failure, just not on
+cancellation). So the next run resumes further along the dependency chain —
+progress is monotonic across runs. Two bounded runs beat one five-hour run that
+risks the hard kill, which *would* lose the cache save.
+
+---
 
 ---
 

--- a/Documentation/usage/ci/build-workflows.md
+++ b/Documentation/usage/ci/build-workflows.md
@@ -97,6 +97,25 @@ the sum of every job.
 Each build-step cap leaves a tail inside its job cap for the push, the cache save
 and the notifier.
 
+#### The real GitHub ceilings, and a number that is easy to misread
+
+| Limit | Value | What happens |
+|---|---|---|
+| Job execution time (GitHub-hosted) | **6 hours / 360 min** | the job is **hard-killed** — post-steps do not run, so the cache save is lost |
+| Workflow run total | 35 days | run is cancelled |
+| Queue wait | 24 h | run is dropped |
+
+⚠️ **There is no 300-minute GitHub limit.** That number looks real because run 761
+died at ~306 minutes, but it was *our own* cap: `build-darwin.yml` had
+`timeout-minutes: 300` on the build step, and the step failed at **300.23 min**,
+on the dot. The job then kept running for a further **3.3 minutes** of post-steps
+and finished normally — which is the proof that GitHub had not killed it.
+
+The distinction matters when choosing caps. A *step* timeout is orderly: later
+steps still run, so the push and the cache save happen. Only the **360-minute
+job** kill is catastrophic, because nothing runs afterwards. Our caps are set to
+stay clear of that, not of 300.
+
 **A tight cap is safe here, and that is not obvious.** Hitting a timeout is not
 data loss: `watch-exec` has already uploaded every path as it was built, and the
 store cache still saves on a timeout (the save step runs on failure, just not on
@@ -410,6 +429,7 @@ what it changed.
 | **1111** | Both hosts in one `nix build`. Runner died at 68 min; build step stuck `in_progress`, push step `pending`, logs 404. Nothing pushed, and no notification | One host per runner (matrix); the `report` watchdog job |
 | **1111** (pre-warm) | Confirmed on the wire: `env: CACHIX_TOKEN: ***` then `Neither auth token nor signing key are present.` and exit 1 — reported by GitHub as step `conclusion: success` | `CACHIX_AUTH_TOKEN` set wherever cachix writes; `cachix-auth` invariant |
 | **1115** (pre-warm) | Auth fix validated: `outcome=success`, `pushed=0`, notifier silent on all 8 legs | — |
+| **761** (darwin, on `main`) | Build step hit its own `timeout-minutes: 300` at 300.23 min and failed. The job then ran post-steps normally for 3.3 min — GitHub did not kill it. **`Push to Cachix` was `skipped`**, because `main`'s gate is `if: steps.build.outcome == 'success'` with no `always()`. Five hours of building, nothing cached | The `always()` push gate, fixed on `develop`. `main` still has the old gate |
 | **1115** (build) | Cancelled by the concurrency group after 27 min. `always()` push step **skipped**, job over in <1s. Log shows 38 `copying path`, **zero** `building` lines, last output at 11:12 then silence — it was still *evaluating*, with repeated `builtins.derivation … options.json` (IFD) warnings | §6.3 rewritten: `always()` is not reliable on cancellation |
 
 ### The 1111 lesson, stated plainly
@@ -509,7 +529,7 @@ Automation cannot resolve these. If one is blocking, it needs the repo owner.
 | Rotating `CACHIX_AUTH_TOKEN` or the Discord webhook secrets | Repository secrets are write-only to CI and unreadable from a session. | Update under Settings → Secrets. |
 | Cachix storage running out | The cache's quota is an account-level setting. | Raise the plan, or `cachix gc`. |
 | Giving CI access to the NAS / `attic` | The NAS is Tailscale-only and CI is deliberately not on the tailnet — see the note in the cachix doc. **This is a decision, not a gap. Do not "fix" it.** | Nothing — it is intentional. |
-| Merging to `main` | `develop` is the integration branch; promotion to `main` is a human call. | Merge when satisfied. |
+| Merging to `main` | `develop` is the integration branch; promotion to `main` is a human call. | Merge when satisfied. **`main` currently still has every pre-fix bug**: `build-darwin.yml` caps of 300/350 and a push gated on `steps.build.outcome == 'success'` with no `always()` — the exact combination that threw away five hours of run 761. Until `develop` is promoted, any build running from `main` can still lose everything it built. |
 | Approving a flake-update PR | A dependency bump is a judgement call about what the machines will run. | Review and merge. |
 
 **Anything an automated session cannot finish should be recorded here rather than

--- a/Documentation/usage/ci/build-workflows.md
+++ b/Documentation/usage/ci/build-workflows.md
@@ -428,6 +428,7 @@ what it changed.
 | **1110** | Baseline, desktop only, warm | build **12m44s**, push 9s, cache save 2m36s, job 19m41s |
 | **1111** | Both hosts in one `nix build`. Runner died at 68 min; build step stuck `in_progress`, push step `pending`, logs 404. Nothing pushed, and no notification | One host per runner (matrix); the `report` watchdog job |
 | **1111** (pre-warm) | Confirmed on the wire: `env: CACHIX_TOKEN: ***` then `Neither auth token nor signing key are present.` and exit 1 — reported by GitHub as step `conclusion: success` | `CACHIX_AUTH_TOKEN` set wherever cachix writes; `cachix-auth` invariant |
+| **1122** | ✅ **First fully green matrix run.** `nixos-desktop` build **10m35s**, push ran (6s); `nixos-laptop` build **10m55s**, push ran (1s); both in parallel, **17m18s wall clock for the pair** — faster than run 1110's 19m41s for the desktop *alone*. Every step green on both legs | Confirms the matrix split; the laptop is effectively free in wall-clock terms |
 | **1115** (pre-warm) | Auth fix validated: `outcome=success`, `pushed=0`, notifier silent on all 8 legs | — |
 | **761** (darwin, on `main`) | Build step hit its own `timeout-minutes: 300` at 300.23 min and failed. The job then ran post-steps normally for 3.3 min — GitHub did not kill it. **`Push to Cachix` was `skipped`**, because `main`'s gate is `if: steps.build.outcome == 'success'` with no `always()`. Five hours of building, nothing cached | The `always()` push gate, fixed on `develop`. `main` still has the old gate |
 | **1115** (build) | Cancelled by the concurrency group after 27 min. `always()` push step **skipped**, job over in <1s. Log shows 38 `copying path`, **zero** `building` lines, last output at 11:12 then silence — it was still *evaluating*, with repeated `builtins.derivation … options.json` (IFD) warnings | §6.3 rewritten: `always()` is not reliable on cancellation |
@@ -452,7 +453,12 @@ Adding `nixos-laptop` to the same `nix build` was justified as "the laptop's
 marginal cost is only its host-specific derivations". Measured, that is false:
 12m44s → died at 68 minutes.
 
-⚠️ **The mechanism is not confirmed.** The first hypothesis was disk exhaustion:
+✅ **The fix is confirmed by run 1122.** One host per runner, and both now build
+in **10m35s / 10m55s** in parallel — 17m18s wall clock for the pair, against
+19m41s for the desktop alone before. So the cost was never the laptop's
+*content*; it was putting two configurations through a single `nix build`.
+
+⚠️ **The underlying mechanism is still not confirmed.** The first hypothesis was disk exhaustion:
 `keep-outputs` retains every *intermediate* output, and the ~78 GiB headroom was
 sized for one closure. Run 1115 does **not** support that. Building the same two
 hosts, it logged 38 substitutions and **zero builds** in 27 minutes, still inside


### PR DESCRIPTION
Follow-up to #42. Two things, both about making a signal mean something.

## Timeout budget

The caps let a single run approach five hours. What matters is the **serial** chain, not the sum — `prewarm-cache` runs before `build-x86_64` via `needs:`.

| | before | after |
|---|---|---|
| `prewarm-cache` job | 120 | **60** |
| `prewarm-cache` step (per leg) | 100 | **45** |
| `build-x86_64` job | 350 | **180** |
| `build-x86_64` build step | 270 | **150** |
| `build-darwin` job | 350 | **180** |
| `build-darwin` build step | 300 | **150** |

Critical path is now `60 + 180 = 240` minutes, clear of both the 300-minute mark and GitHub's 360-minute hard kill.

**A tight cap is safe here, and that isn't obvious.** Hitting a timeout is not data loss: `watch-exec` has already uploaded every path as it was built, and the store cache still saves on a timeout (the save step runs on failure — just not on cancellation). The next run resumes further along, so progress is monotonic. Two bounded runs beat one five-hour run that risks the hard kill, which *would* lose the cache save.

## Shellcheck: 12 permanent findings → 0

The advisory shellcheck step was permanently dirty, and its failure fires a Discord warning — so it would have warned on **every run, forever**. A signal that always fires isn't a signal.

**Genuine, fixed.** The `deadnix` step wrote to `$GITHUB_ENV` unquoted, five times. Every other `GITHUB_OUTPUT`/`GITHUB_ENV` write in these workflows quotes the path; this was the only one that didn't. Also grouped into a single redirect.

**Intentional, annotated.** Six sites rely on word splitting and would **break** if quoted as SC2046 asks:

- `cachix push <cache> $(cat outpaths.txt)` and `nix path-info -sh -r $(cat outpaths.txt)` — one store path per line must become one argument per path. Quoting passes the whole file as a single argument.
- `sudo rm -f $(grep -lr ...)` — each matched file must be its own argument.

Each now carries an inline `# shellcheck disable=SC2046` with the reason, rather than a global suppression, so the rule still applies everywhere else.

`actionlint` + shellcheck is now clean, which means the next finding will mean something.

## Docs

Adds the timeout-budget table to `Documentation/usage/ci/build-workflows.md`, including why a tight cap is safe.

Fixes the last confirmed error in the cachix doc, found by the parallel fact-check: *"Trigger: Automatically runs on every `git push`"* in the Tier 1 summary. `push` is filtered to `develop`/`main`, so a feature branch with no PR open builds nothing — and the same document already said so correctly further down.

## Verification

- `actionlint` clean, both with and without shellcheck
- 117 workflow invariants hold
- `bash -n` over all 38 `run:` blocks — 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeyWXPgCudXoKEit4LLDkS)_