### PR TITLE
ci: bound the apt-get steps, and stop a best-effort step failing the suite

### DIFF
--- a/.github/scripts/check-workflow-invariants.py
+++ b/.github/scripts/check-workflow-invariants.py
@@ -181,6 +181,22 @@ def check_workflow(path):
                              f"matrix variable. All legs of a run share run_id/run_attempt, so "
                              f"the keys collide.")
 
+            # 13. A step that shells out to a package manager must declare
+            #     timeout-minutes. continue-on-error and `|| true` cover a step
+            #     FAILING; neither covers it HANGING. Run 1130: apt-get stalled on
+            #     an unreachable mirror, the step sat 27+ minutes holding the job
+            #     toward its cap, and it blocked every later run in the same
+            #     concurrency group - and the runner was unreachable, so a manual
+            #     Cancel could not be delivered either.
+            if re.search(r"\b(apt-get|apt|yum|dnf|brew|pacman)\s+(update|install|upgrade)\b", run):
+                checked += 1
+                if step.get("timeout-minutes") is None:
+                    fail(wf, job_name, name, "package-manager-timeout",
+                         "shells out to a package manager without timeout-minutes. "
+                         "continue-on-error and `|| true` cover failure, not hanging - a "
+                         "stalled mirror can hold the job to its cap and block every later "
+                         "run in the concurrency group. (run 1130)")
+
             # 11. Every curl to a Discord webhook must use --fail. Without it curl
             #     exits 0 on an HTTP 4xx/5xx, so a rotated or revoked webhook token
             #     reports a delivered notification that never arrived.

--- a/.github/scripts/check-workflow-invariants.py
+++ b/.github/scripts/check-workflow-invariants.py
@@ -181,14 +181,20 @@ def check_workflow(path):
                              f"matrix variable. All legs of a run share run_id/run_attempt, so "
                              f"the keys collide.")
 
-            # 13. A step that shells out to a package manager must declare
+            # 10. A step that shells out to a package manager must declare
             #     timeout-minutes. continue-on-error and `|| true` cover a step
             #     FAILING; neither covers it HANGING. Run 1130: apt-get stalled on
             #     an unreachable mirror, the step sat 27+ minutes holding the job
             #     toward its cap, and it blocked every later run in the same
             #     concurrency group - and the runner was unreachable, so a manual
             #     Cancel could not be delivered either.
-            if re.search(r"\b(apt-get|apt|yum|dnf|brew|pacman)\s+(update|install|upgrade)\b", run):
+            # The verb may be separated from the command by any number of flags
+            # or their values (`apt-get -y install`, `apt-get -o Acquire::Retries=3
+            # update`), so intervening tokens are allowed - but bounded by shell
+            # separators so a match cannot run past the end of the command.
+            _PKG = r"(?:apt-get|apt|yum|dnf|brew|pacman|apk|zypper)"
+            _VERB = r"(?:update|upgrade|install|add)"
+            if re.search(rf"\b{_PKG}\b(?:\s+(?!{_VERB}\b)[^\s;|&]+)*\s+{_VERB}\b", run):
                 checked += 1
                 if step.get("timeout-minutes") is None:
                     fail(wf, job_name, name, "package-manager-timeout",
@@ -208,7 +214,7 @@ def check_workflow(path):
                          "4xx/5xx, so a rotated or revoked token is reported as a delivered "
                          "notification that in fact never arrived.")
 
-            # 10. A notifier that can fire without a webhook configured spams
+            # 12. A notifier that can fire without a webhook configured spams
             #     errors; one that is not continue-on-error can fail the job for a
             #     Discord outage.
             if "discord.com/api/webhooks" in str(step.get("env", {})) or "WEBHOOK_URL" in run:
@@ -225,7 +231,7 @@ def check_workflow(path):
 
 
 def check_cache_keys(path):
-    """12. A restore prefix that matches no save key means the job silently always
+    """13. A restore prefix that matches no save key means the job silently always
     runs cold. Introduced for real by reordering a matrix variable into the middle
     of the save key while a sibling job still restored the old prefix - nothing
     errors, the cache simply never hits again.

--- a/.github/scripts/check-workflow-invariants.py
+++ b/.github/scripts/check-workflow-invariants.py
@@ -203,7 +203,19 @@ def check_workflow(path):
                          "stalled mirror can hold the job to its cap and block every later "
                          "run in the concurrency group. (run 1130)")
 
-            # 11. Every curl to a Discord webhook must use --fail. Without it curl
+            # 11. A best-effort optimisation action must never be able to fail a
+            #     job. nothing-but-nix frees disk; it is a speedup, not a
+            #     correctness requirement. build.yml guarded it, tests-nixos.yml
+            #     did not, and on 2026-08-19 it failed there and skipped all six
+            #     tests - which the summary then reported as six FAILURES.
+            if "wimpysworld/nothing-but-nix" in step.get("uses", ""):
+                checked += 1
+                if step.get("continue-on-error") is not True:
+                    fail(wf, job_name, name, "besteffort-non-fatal",
+                         "uses nothing-but-nix without continue-on-error: true. It frees "
+                         "disk as an optimisation and must never fail a job on its own.")
+
+            # 12. Every curl to a Discord webhook must use --fail. Without it curl
             #     exits 0 on an HTTP 4xx/5xx, so a rotated or revoked webhook token
             #     reports a delivered notification that never arrived.
             if "WEBHOOK_URL" in run and "curl" in run:
@@ -214,7 +226,7 @@ def check_workflow(path):
                          "4xx/5xx, so a rotated or revoked token is reported as a delivered "
                          "notification that in fact never arrived.")
 
-            # 12. A notifier that can fire without a webhook configured spams
+            # 13. A notifier that can fire without a webhook configured spams
             #     errors; one that is not continue-on-error can fail the job for a
             #     Discord outage.
             if "discord.com/api/webhooks" in str(step.get("env", {})) or "WEBHOOK_URL" in run:
@@ -231,7 +243,7 @@ def check_workflow(path):
 
 
 def check_cache_keys(path):
-    """13. A restore prefix that matches no save key means the job silently always
+    """14. A restore prefix that matches no save key means the job silently always
     runs cold. Introduced for real by reordering a matrix variable into the middle
     of the save key while a sibling job still restored the old prefix - nothing
     errors, the cache simply never hits again.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,14 @@ jobs:
 
       - name: Install CA Certificates
         continue-on-error: true
+        # timeout-minutes is load-bearing, not decoration. continue-on-error and
+        # the `|| true` below cover this step FAILING; neither covers it HANGING.
+        # Run 1130 lost a whole job to exactly that: apt-get stalled on an
+        # unreachable mirror and the step sat for 27+ minutes, holding the job
+        # toward its 180-minute cap AND blocking every later run in the same
+        # concurrency group - and because the runner itself was unreachable, a
+        # manual Cancel could not be delivered either.
+        timeout-minutes: 5
         run: |
           # Best-effort freshness refresh: ca-certificates is preinstalled on
           # the runner image and Nix uses its own CA bundle (NIX_SSL_CERT_FILE),
@@ -623,6 +631,14 @@ jobs:
 
       - name: Install CA Certificates
         continue-on-error: true
+        # timeout-minutes is load-bearing, not decoration. continue-on-error and
+        # the `|| true` below cover this step FAILING; neither covers it HANGING.
+        # Run 1130 lost a whole job to exactly that: apt-get stalled on an
+        # unreachable mirror and the step sat for 27+ minutes, holding the job
+        # toward its 180-minute cap AND blocking every later run in the same
+        # concurrency group - and because the runner itself was unreachable, a
+        # manual Cancel could not be delivered either.
+        timeout-minutes: 5
         run: |
           # Best-effort freshness refresh: ca-certificates is preinstalled on
           # the runner image and Nix uses its own CA bundle (NIX_SSL_CERT_FILE),

--- a/.github/workflows/tests-nixos.yml
+++ b/.github/workflows/tests-nixos.yml
@@ -46,6 +46,11 @@ jobs:
         run: sudo chmod 1777 /mnt
 
       - name: Maximize Nix Space
+        # Best-effort disk optimisation - it must never fail the suite. build.yml
+        # already guarded this; tests-nixos.yml did not, and on 2026-08-19 it
+        # failed here and skipped all six tests, which the summary below then
+        # reported as six FAILURES.
+        continue-on-error: true
         uses: wimpysworld/nothing-but-nix@main
         with:
           hatchet-protocol: "cleave"
@@ -157,20 +162,40 @@ jobs:
         run: |
 
           FAILED=()
+          SKIPPED=()
 
-          [[ "$MINIMAL_OUTCOME"    != "success" ]] && FAILED+=("✗  minimal-defaults")
-          [[ "$SPEC_OUTCOME"       != "success" ]] && FAILED+=("✗  spec-contract")
-          [[ "$CONFLICT_OUTCOME"   != "success" ]] && FAILED+=("✗  conflicting-modules")
-          [[ "$SHELLS_OUTCOME"     != "success" ]] && FAILED+=("✗  custom-shells")
-          [[ "$ARCH_OUTCOME"       != "success" ]] && FAILED+=("✗  arch-compat (aarch64)")
-          [[ "$WALLPAPERS_OUTCOME" != "success" ]] && FAILED+=("✗  wallpapers")
+          # A test that never RAN is not a test that FAILED. Before this, any
+          # earlier step dying skipped every test and the summary then announced
+          # six failures that had not happened - a Discord notice naming six
+          # broken tests when none had executed. Classify the two separately.
+          # Appended inside `if` blocks, never as `[[ ... ]] &&`: under `bash -e`
+          # a false test makes that list return non-zero and aborts the step at
+          # the first line that does not apply.
+          classify() {
+            case "$2" in
+              success) ;;
+              skipped) SKIPPED+=("-  $1") ;;
+              *)       FAILED+=("✗  $1") ;;
+            esac
+          }
+          classify "minimal-defaults"     "$MINIMAL_OUTCOME"
+          classify "spec-contract"        "$SPEC_OUTCOME"
+          classify "conflicting-modules"  "$CONFLICT_OUTCOME"
+          classify "custom-shells"        "$SHELLS_OUTCOME"
+          classify "arch-compat (aarch64)" "$ARCH_OUTCOME"
+          classify "wallpapers"           "$WALLPAPERS_OUTCOME"
+
+          if [[ ${#SKIPPED[@]} -gt 0 ]]; then
+            echo "::warning::${#SKIPPED[@]} test(s) never ran - an earlier step failed: ${SKIPPED[*]}"
+            FAILED+=("${SKIPPED[@]}")
+          fi
 
           if [[ ${#FAILED[@]} -eq 0 ]]; then
             echo "All NixOS tests passed."
             exit 0
           fi
 
-          echo "Failed tests: ${FAILED[*]}"
+          echo "Not passing: ${FAILED[*]}"
 
           if [[ -n "$WEBHOOK_ID" ]]; then
             REPORT=$(printf '%s\n' "${FAILED[@]}")

--- a/.github/workflows/tests-nixos.yml
+++ b/.github/workflows/tests-nixos.yml
@@ -30,7 +30,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install CA Certificates
-        run: sudo apt-get update && sudo apt-get install -y ca-certificates
+        # Best-effort, and bounded. ca-certificates is preinstalled on the
+        # runner image and Nix uses its own CA bundle, so a broken third-party
+        # apt repo must not fail the suite - and `timeout-minutes` covers the
+        # case `|| true` cannot: apt HANGING rather than failing. Run 1130 lost
+        # a job to a 27-minute apt stall that a manual Cancel could not reach.
+        continue-on-error: true
+        timeout-minutes: 5
+        run: sudo apt-get update || true; sudo apt-get install -y ca-certificates || true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/Documentation/usage/ci/build-workflows.md
+++ b/Documentation/usage/ci/build-workflows.md
@@ -532,6 +532,29 @@ whole file as a single argument and break every push.
   like a delivered notification. Use `--fail`. (`webhook-curl-fail`.)
 - **`grep -c` exits 1 on zero matches** under `-e`; the `|| true` on the
   `pushed=` lines is load-bearing.
+- **A newer run does NOT displace a running one.** `cancel-in-progress: true`
+  cancels *pending* runs in the group; a run already `in_progress` keeps going
+  and the newcomer queues behind it. Observed repeatedly (1111 vs 1112-1114,
+  1130 vs 1131/1132). So a stuck job blocks every later run on the same ref.
+- **`if: always()` at JOB level survives run cancellation.** When run 1130 was
+  superseded, its `flake-check` and all 8 pre-warm legs were cancelled — and its
+  two `build-x86_64` legs were created **7 seconds later** and ran to completion
+  anyway, because that job carries `if: always()`. Useful, but it means a
+  cancelled run can still hold the concurrency slot for hours.
+- **A hung step is not a failed step.** `continue-on-error` and `|| true` cover a
+  command *failing*; neither covers it *hanging*. Run 1130's `Install CA
+  Certificates` stalled on an unreachable apt mirror for 27+ minutes, and
+  because the runner itself was unreachable a manual **Cancel could not be
+  delivered** — the job was unkillable until its 180-minute cap. Anything that
+  can block on the network needs `timeout-minutes`. Guarded by the
+  `package-manager-timeout` invariant.
+- **Escaping a blocked concurrency group:** the group is
+  `workflow + github.ref`, so a run on a *different* ref is unaffected. Opening a
+  PR from a branch at the same commit gets a build on `refs/pull/N/merge` and
+  starts immediately, without waiting for the stuck run on `develop`.
+- **`list_workflow_runs` with a `branch` filter can return STALE data** — it
+  served two-week-old runs repeatedly while today's were live. Query without the
+  filter and sort client-side by `created_at`.
 - **GitHub's queue.** Runs can sit `pending` for 20+ minutes. Observed: an older
   in-progress run continuing while newer runs in the same concurrency group were
   cancelled, and the newest held `pending` until the old one ended. Be patient


### PR DESCRIPTION
Three commits, all from failures observed today rather than speculation.

## 1. A hung `apt-get` blocked the whole queue

`Install CA Certificates` stalled on an unreachable apt mirror and sat for **27+ minutes** — a step that normally takes 10 seconds.

`continue-on-error: true` and `|| true` cover that step **failing**. Neither covers it **hanging**. With no `timeout-minutes` the job headed for its full 180-minute cap, and because the runner itself had become unreachable, a manual **Cancel could not be delivered** — the job was unkillable.

The damage wasn't confined to that job: `cancel-in-progress` only cancels **pending** runs, so a run already `in_progress` keeps its concurrency slot. One hung step on `develop` blocked every later run behind it.

| file | change |
|---|---|
| `build.yml` | `timeout-minutes: 5` on both `Install CA Certificates` steps |
| `tests-nixos.yml` | same, **plus** `continue-on-error` — it had none, and its `&&` chain had no `\|\| true` either |

`build-darwin.yml` needs nothing — macOS, no `apt-get`.

**Confirmed working:** the same hang recurred four times today and was bounded at 5m12s each time instead of running unkillably.

## 2. The package-manager regex missed the commonest form

Caught in review, and correct. The first version required the verb to follow the command immediately, so it matched `apt-get update` but missed **four of seven** realistic invocations:

```
match=False  sudo apt-get -y install ca-certificates          <- the commonest shape
match=False  sudo apt-get -o Acquire::Retries=3 update
match=False  sudo apt-get -qq --no-install-recommends install foo
match=False  sudo dnf -y upgrade
```

The repo's own files happened to match, so the check passed — a check that silently covers less than it claims reads as coverage without being coverage.

Now the verb may be preceded by any number of flags **or their values**, bounded by shell separators so a match can't run past the end of the command. `apk` and `zypper` added. Verified 9/9 positives and 5/5 negatives.

## 3. A best-effort disk step failed the test suite, and the summary cried wolf

`test-nixos` went red, and neither cause was the change under test:

```
Install CA Certificates   5m12s, success   <- the new timeout, working
Maximize Nix Space        FAILURE          <- killed the job
all six tests             skipped
Summary                   "Failed tests: minimal-defaults spec-contract ..."
```

- **`Maximize Nix Space` could fail the suite.** `nothing-but-nix` frees disk — an optimisation, not a correctness requirement. `build.yml` always guarded it with `continue-on-error`; `tests-nixos.yml` did not.
- **The summary reported six failures when nothing had run.** It treated any outcome `!= success` as a failure, so `skipped` became `failed` — and it would have sent a Discord notice naming six broken tests that never executed. Skipped is now classified separately, via a `case` statement rather than `[[ ... ]] && …`, which under `bash -e` aborts at the first line whose test is false.

## Invariants

Two new, both mutation-tested by reintroducing the bug and confirming the checker fails:

- `package-manager-timeout` — any step shelling out to `apt`/`apt-get`/`yum`/`dnf`/`brew`/`pacman`/`apk`/`zypper` must declare `timeout-minutes`
- `besteffort-non-fatal` — `nothing-but-nix` must be `continue-on-error`, keeping `build.yml` and `tests-nixos.yml` symmetric

**122 invariants, all holding.** actionlint clean with and without shellcheck. Numbering renumbered to be strictly increasing in file order.

## Documented

Three behaviours learned the hard way today:

- **A newer run does not displace a running one** — only *pending* runs are cancelled (1111 vs 1112–1114; 1130 vs 1131/1132).
- **`if: always()` at *job* level survives run cancellation** — 1130's build legs were created **7 seconds after** its other jobs were cancelled and ran to completion.
- **`list_workflow_runs` with a `branch` filter returns stale data** — it served two-week-old runs while today's were live.

## CI status

`check-workflows`, `test-darwin` and all 8 pre-warm legs are green. `flake-check` and the two build legs fail on `ffmpeg_9`, which is **inherited from `develop`'s `flake.lock`** (merged in #44) and red on the base branch too. This PR changes 4 files, **zero of them `.nix`**, so it cannot cause a Nix evaluation failure — deliberately not widened to chase it.