### PR TITLE
test(wallpapers): fix mpvpaper assertion literals in wallpaper suite

### DIFF
--- a/templates/tests/nixos/test-nixos-wallpapers/02-gif-no-waypaper_test.nix
+++ b/templates/tests/nixos/test-nixos-wallpapers/02-gif-no-waypaper_test.nix
@@ -21,8 +21,8 @@ nix-tests.runTests {
   "W02: x86_64 gif+static wallpaper, no waypaper" = helpers: {
     "hyprland exec contains awww-daemon" =
       helpers.isTrue (H.hyprExecHas "awww-daemon" config);
-    "hyprland exec contains mpvpaper -f -o loop ALL (gif dispatched via mpvpaper, wildcard monitor)" =
-      helpers.isTrue (H.hyprExecHas "mpvpaper -f -o loop ALL" config);
+    "hyprland exec contains mpvpaper -f -o \"loop mute=yes\" ALL (gif dispatched via mpvpaper, wildcard monitor)" =
+      helpers.isTrue (H.hyprExecHas "mpvpaper -f -o \\\"loop mute=yes\\\" ALL" config);
     "hyprland exec contains gif filename (gif path chosen over static)" =
       helpers.isTrue (H.hyprExecHas gifFile config);
     "hyprland exec does NOT contain awww img (gif wins over static)" =
@@ -31,16 +31,16 @@ nix-tests.runTests {
       helpers.isFalse (H.hyprExecHas "waypaper --restore" config);
     "mango exec contains awww-daemon" =
       helpers.isTrue (H.mangoExecHas "awww-daemon" config);
-    "mango exec contains mpvpaper -f -o loop ALL" =
-      helpers.isTrue (H.mangoExecHas "mpvpaper -f -o loop ALL" config);
+    "mango exec contains mpvpaper -f -o \"loop mute=yes\" ALL" =
+      helpers.isTrue (H.mangoExecHas "mpvpaper -f -o \"loop mute=yes\" ALL" config);
     "mango exec does NOT contain awww img" =
       helpers.isFalse (H.mangoExecHas "awww img" config);
     "mango exec does NOT contain waypaper --restore" =
       helpers.isFalse (H.mangoExecHas "waypaper --restore" config);
     "niri spawn contains awww-daemon" =
       helpers.isTrue (H.niriSpawnHas "awww-daemon" config);
-    "niri spawn contains mpvpaper -f -o loop ALL" =
-      helpers.isTrue (H.niriSpawnHas "mpvpaper -f -o loop ALL" config);
+    "niri spawn contains mpvpaper -f -o \"loop mute=yes\" ALL" =
+      helpers.isTrue (H.niriSpawnHas "mpvpaper -f -o \"loop mute=yes\" ALL" config);
     "niri spawn does NOT contain awww img" =
       helpers.isFalse (H.niriSpawnHas "awww img" config);
     "niri spawn does NOT contain waypaper --restore" =

--- a/templates/tests/nixos/test-nixos-wallpapers/05-aarch64-gif-no-waypaper_test.nix
+++ b/templates/tests/nixos/test-nixos-wallpapers/05-aarch64-gif-no-waypaper_test.nix
@@ -15,8 +15,8 @@ nix-tests.runTests {
   "W05: aarch64 gif+static wallpaper, no waypaper" = helpers: {
     "hyprland exec contains awww-daemon" =
       helpers.isTrue (H.hyprExecHas "awww-daemon" config);
-    "hyprland exec contains mpvpaper -f -o loop ALL (gif path)" =
-      helpers.isTrue (H.hyprExecHas "mpvpaper -f -o loop ALL" config);
+    "hyprland exec contains mpvpaper -f -o \"loop mute=yes\" ALL (gif path)" =
+      helpers.isTrue (H.hyprExecHas "mpvpaper -f -o \\\"loop mute=yes\\\" ALL" config);
     "hyprland exec contains gif filename" =
       helpers.isTrue (H.hyprExecHas gifFile config);
     "hyprland exec does NOT contain awww img" =
@@ -25,12 +25,12 @@ nix-tests.runTests {
       helpers.isFalse (H.hyprExecHas "waypaper --restore" config);
     "mango exec contains awww-daemon" =
       helpers.isTrue (H.mangoExecHas "awww-daemon" config);
-    "mango exec contains mpvpaper -f -o loop ALL" =
-      helpers.isTrue (H.mangoExecHas "mpvpaper -f -o loop ALL" config);
+    "mango exec contains mpvpaper -f -o \"loop mute=yes\" ALL" =
+      helpers.isTrue (H.mangoExecHas "mpvpaper -f -o \"loop mute=yes\" ALL" config);
     "niri spawn contains awww-daemon" =
       helpers.isTrue (H.niriSpawnHas "awww-daemon" config);
-    "niri spawn contains mpvpaper -f -o loop ALL" =
-      helpers.isTrue (H.niriSpawnHas "mpvpaper -f -o loop ALL" config);
+    "niri spawn contains mpvpaper -f -o \"loop mute=yes\" ALL" =
+      helpers.isTrue (H.niriSpawnHas "mpvpaper -f -o \"loop mute=yes\" ALL" config);
     "gnome uses static store path (not gifURL)" =
       helpers.isTrue (lib.hasPrefix "file:///nix/store/" (builtins.toString gnomeBgUri));
     "kde plasma wallpaper list non-empty (static)" =

--- a/templates/tests/nixos/test-nixos-wallpapers/12-video-no-waypaper_test.nix
+++ b/templates/tests/nixos/test-nixos-wallpapers/12-video-no-waypaper_test.nix
@@ -19,20 +19,20 @@ nix-tests.runTests {
   "W12: x86_64 video+static wallpaper, no waypaper" = helpers: {
     "hyprland exec contains awww-daemon" =
       helpers.isTrue (H.hyprExecHas "awww-daemon" config);
-    "hyprland exec contains mpvpaper -f -o loop ALL (video wins over static)" =
-      helpers.isTrue (H.hyprExecHas "mpvpaper -f -o loop ALL" config);
+    "hyprland exec contains mpvpaper -f -o \"loop mute=yes\" ALL (video wins over static)" =
+      helpers.isTrue (H.hyprExecHas "mpvpaper -f -o \\\"loop mute=yes\\\" ALL" config);
     "hyprland exec contains video filename" =
       helpers.isTrue (H.hyprExecHas videoFile config);
     "hyprland exec does NOT contain awww img" =
       helpers.isFalse (H.hyprExecHas "awww img" config);
     "hyprland exec does NOT contain waypaper --restore" =
       helpers.isFalse (H.hyprExecHas "waypaper --restore" config);
-    "mango exec contains mpvpaper -f -o loop ALL" =
-      helpers.isTrue (H.mangoExecHas "mpvpaper -f -o loop ALL" config);
+    "mango exec contains mpvpaper -f -o \"loop mute=yes\" ALL" =
+      helpers.isTrue (H.mangoExecHas "mpvpaper -f -o \"loop mute=yes\" ALL" config);
     "mango exec does NOT contain awww img" =
       helpers.isFalse (H.mangoExecHas "awww img" config);
-    "niri spawn contains mpvpaper -f -o loop ALL" =
-      helpers.isTrue (H.niriSpawnHas "mpvpaper -f -o loop ALL" config);
+    "niri spawn contains mpvpaper -f -o \"loop mute=yes\" ALL" =
+      helpers.isTrue (H.niriSpawnHas "mpvpaper -f -o \"loop mute=yes\" ALL" config);
     "niri spawn does NOT contain awww img" =
       helpers.isFalse (H.niriSpawnHas "awww img" config);
     # GNOME always uses the static wallpaperURL (videoURL is WM-only)

--- a/templates/tests/nixos/test-nixos-wallpapers/13-video-gif-static-priority_test.nix
+++ b/templates/tests/nixos/test-nixos-wallpapers/13-video-gif-static-priority_test.nix
@@ -16,20 +16,20 @@ let
 in
 nix-tests.runTests {
   "W13: x86_64 video+gif+static wallpaper, no waypaper" = helpers: {
-    "hyprland exec contains mpvpaper -f -o loop ALL (video wins over gif+static)" =
-      helpers.isTrue (H.hyprExecHas "mpvpaper -f -o loop ALL" config);
+    "hyprland exec contains mpvpaper -f -o \"loop mute=yes\" ALL (video wins over gif+static)" =
+      helpers.isTrue (H.hyprExecHas "mpvpaper -f -o \\\"loop mute=yes\\\" ALL" config);
     "hyprland exec contains video filename" =
       helpers.isTrue (H.hyprExecHas videoFile config);
     "hyprland exec does NOT contain gif filename (video beats gif)" =
       helpers.isFalse (H.hyprExecHas gifFile config);
     "hyprland exec does NOT contain awww img" =
       helpers.isFalse (H.hyprExecHas "awww img" config);
-    "mango exec contains mpvpaper -f -o loop ALL" =
-      helpers.isTrue (H.mangoExecHas "mpvpaper -f -o loop ALL" config);
+    "mango exec contains mpvpaper -f -o \"loop mute=yes\" ALL" =
+      helpers.isTrue (H.mangoExecHas "mpvpaper -f -o \"loop mute=yes\" ALL" config);
     "mango exec does NOT contain gif filename" =
       helpers.isFalse (H.mangoExecHas gifFile config);
-    "niri spawn contains mpvpaper -f -o loop ALL" =
-      helpers.isTrue (H.niriSpawnHas "mpvpaper -f -o loop ALL" config);
+    "niri spawn contains mpvpaper -f -o \"loop mute=yes\" ALL" =
+      helpers.isTrue (H.niriSpawnHas "mpvpaper -f -o \"loop mute=yes\" ALL" config);
     "niri spawn does NOT contain gif filename" =
       helpers.isFalse (H.niriSpawnHas gifFile config);
     # GNOME/KDE always use the static wallpaperURL regardless of gif/video

--- a/templates/tests/nixos/test-nixos-wallpapers/15-named-monitor-video_test.nix
+++ b/templates/tests/nixos/test-nixos-wallpapers/15-named-monitor-video_test.nix
@@ -7,20 +7,20 @@ let
 in
 nix-tests.runTests {
   "W15: named monitor generates -o DP-1 in mpvpaper commands" = helpers: {
-    "hyprland exec contains mpvpaper -f -o loop DP-1 for named monitor" =
-      helpers.isTrue (H.hyprExecHas "mpvpaper -f -o loop DP-1" config);
-    "hyprland exec does NOT contain mpvpaper -f -o loop ALL" =
-      helpers.isFalse (H.hyprExecHas "mpvpaper -f -o loop ALL" config);
+    "hyprland exec contains mpvpaper -f -o \"loop mute=yes\" DP-1 for named monitor" =
+      helpers.isTrue (H.hyprExecHas "mpvpaper -f -o \\\"loop mute=yes\\\" DP-1" config);
+    "hyprland exec does NOT contain mpvpaper -f -o \"loop mute=yes\" ALL" =
+      helpers.isFalse (H.hyprExecHas "mpvpaper -f -o \\\"loop mute=yes\\\" ALL" config);
     "hyprland exec does NOT contain awww img" =
       helpers.isFalse (H.hyprExecHas "awww img" config);
     "hyprland exec does NOT contain waypaper --restore" =
       helpers.isFalse (H.hyprExecHas "waypaper --restore" config);
-    "mango exec contains mpvpaper -f -o loop DP-1 for named monitor" =
-      helpers.isTrue (H.mangoExecHas "mpvpaper -f -o loop DP-1" config);
+    "mango exec contains mpvpaper -f -o \"loop mute=yes\" DP-1 for named monitor" =
+      helpers.isTrue (H.mangoExecHas "mpvpaper -f -o \"loop mute=yes\" DP-1" config);
     "mango exec does NOT contain awww img" =
       helpers.isFalse (H.mangoExecHas "awww img" config);
-    "niri spawn contains mpvpaper -f -o loop DP-1 for named monitor" =
-      helpers.isTrue (H.niriSpawnHas "mpvpaper -f -o loop DP-1" config);
+    "niri spawn contains mpvpaper -f -o \"loop mute=yes\" DP-1 for named monitor" =
+      helpers.isTrue (H.niriSpawnHas "mpvpaper -f -o \"loop mute=yes\" DP-1" config);
     "niri spawn does NOT contain awww img" =
       helpers.isFalse (H.niriSpawnHas "awww img" config);
   };

--- a/templates/tests/nixos/test-nixos-wallpapers/test-nixos-wallpapers-readme.md
+++ b/templates/tests/nixos/test-nixos-wallpapers/test-nixos-wallpapers-readme.md
@@ -32,7 +32,7 @@ The `_test.nix` files assert substring presence/absence in the WM exec strings a
 |-----------|---------------|
 | Shell active on this WM | neither `awww-daemon`/`mpvpaper` nor `waypaper --restore` |
 | `waypaper.enable = false`, no shell, only `wallpaperURL` set | `awww-daemon` + `awww img <path>` |
-| `waypaper.enable = false`, no shell, `gifURL` or `videoURL` set | `mpvpaper -f -o loop <output> <path>` (not `awww img`) |
+| `waypaper.enable = false`, no shell, `gifURL` or `videoURL` set | `mpvpaper -f -o "loop mute=yes" <output> <path>` (not `awww img`) |
 | `waypaper.enable = true`, no shell | `waypaper --restore` (wins over static/gif/video regardless of which are set) |
 | `videoURL` set | video wins over gif and static - mpvpaper uses `videoURL` |
 | `gifURL` set (no `videoURL`) | gif wins over static - mpvpaper uses `gifURL` |
@@ -63,7 +63,7 @@ The `_test.nix` files assert substring presence/absence in the WM exec strings a
 | Check | Expected |
 |-------|----------|
 | hyprland exec contains `awww-daemon` | true |
-| hyprland exec contains `mpvpaper -f -o loop ALL` (gif via mpvpaper, wildcard monitor) | true |
+| hyprland exec contains `mpvpaper -f -o "loop mute=yes" ALL` (gif via mpvpaper, wildcard monitor) | true |
 | hyprland exec contains gif filename (gif wins over static) | true |
 | hyprland exec contains `awww img` | false |
 | hyprland exec contains `waypaper --restore` | false |
@@ -99,10 +99,10 @@ The `_test.nix` files assert substring presence/absence in the WM exec strings a
 | Check | Expected |
 |-------|----------|
 | hyprland exec contains `awww-daemon` | true |
-| hyprland exec contains `mpvpaper -f -o loop ALL` (gif via mpvpaper) | true |
+| hyprland exec contains `mpvpaper -f -o "loop mute=yes" ALL` (gif via mpvpaper) | true |
 | hyprland exec contains gif filename | true |
 | hyprland exec contains `waypaper --restore` | false |
-| mango/niri exec contain `mpvpaper -f -o loop ALL` | true |
+| mango/niri exec contain `mpvpaper -f -o "loop mute=yes" ALL` | true |
 | GNOME background URI has `file:///nix/store/` prefix | true |
 | KDE plasma wallpaper list non-empty | true |
 
@@ -177,11 +177,11 @@ The `_test.nix` files assert substring presence/absence in the WM exec strings a
 | Check | Expected |
 |-------|----------|
 | hyprland exec contains `awww-daemon` | true |
-| hyprland exec contains `mpvpaper -f -o loop ALL` (video wins over static, wildcard monitor) | true |
+| hyprland exec contains `mpvpaper -f -o "loop mute=yes" ALL` (video wins over static, wildcard monitor) | true |
 | hyprland exec contains video filename | true |
 | hyprland exec contains `awww img` | false |
 | hyprland exec contains `waypaper --restore` | false |
-| mango/niri exec contain `mpvpaper -f -o loop ALL`, not `awww img` | true |
+| mango/niri exec contain `mpvpaper -f -o "loop mute=yes" ALL`, not `awww img` | true |
 | GNOME background URI has `file:///nix/store/` prefix (static, DEs never see videoURL) | true |
 | KDE plasma wallpaper list non-empty | true |
 
@@ -189,7 +189,7 @@ The `_test.nix` files assert substring presence/absence in the WM exec strings a
 
 | Check | Expected |
 |-------|----------|
-| hyprland/mango/niri exec contain `mpvpaper -f -o loop ALL` (video wins over gif and static) | true |
+| hyprland/mango/niri exec contain `mpvpaper -f -o "loop mute=yes" ALL` (video wins over gif and static) | true |
 | hyprland exec contains video filename | true |
 | hyprland exec contains gif filename (video beats gif) | false |
 | hyprland exec contains `awww img` | false |
@@ -212,8 +212,8 @@ The `_test.nix` files assert substring presence/absence in the WM exec strings a
 
 | Check | Expected |
 |-------|----------|
-| hyprland exec contains `mpvpaper -f -o loop DP-1` (named monitor, mpvpaper syntax) | true |
-| hyprland exec contains `mpvpaper -f -o loop ALL` | false |
+| hyprland exec contains `mpvpaper -f -o "loop mute=yes" DP-1` (named monitor, mpvpaper syntax) | true |
+| hyprland exec contains `mpvpaper -f -o "loop mute=yes" ALL` | false |
 | hyprland exec contains `awww img` | false |
 | hyprland exec contains `waypaper --restore` | false |
-| mango/niri exec contain `mpvpaper -f -o loop DP-1`, not `awww img` | true/false as above |
+| mango/niri exec contain `mpvpaper -f -o "loop mute=yes" DP-1`, not `awww img` | true/false as above |


### PR DESCRIPTION
## What

Fixes 5 failing files (14 failed assertions total) in `templates/tests/nixos/test-nixos-wallpapers/`. This is a **test-authorship fix only** — no module or config code changed.

## Root cause

The failing assertions all checked for the literal substring:

```
mpvpaper -f -o loop <MONITOR>
```

But the wallpaper module (`modules/nixos/programs/de-wm/{hyprland,mango,niri}-main.nix`) has never emitted that string. It actually emits:

```
mpvpaper -f -o "loop mute=yes" <MONITOR>
```

— quoted, and with `mute=yes` appended. The tests were asserting a command that was never generated, so they failed unconditionally regardless of whether the underlying video/gif/static dispatch logic was correct.

### Hyprland-specific wrinkle

Hyprland needed a further, WM-specific correction. Its `exec-once` commands are wrapped via:

```nix
hl.exec_cmd(${builtins.toJSON cmd})
```

`builtins.toJSON` re-escapes the embedded `"` characters as `\"` when rendering the Hyprland lua config, so Hyprland's actual emitted substring is:

```
mpvpaper -f -o \"loop mute=yes\" <MONITOR>
```

This is distinct from mango/niri, which emit the raw, unescaped `"loop mute=yes"` form (no JSON wrapping in their exec paths). The fixed assertions are now WM-specific to reflect this — Hyprland cases assert the backslash-escaped form, mango/niri cases assert the raw quoted form.

## Why this was a test bug, not a module bug

Every other assertion in these same 5 files — filename presence/absence for video vs. gif vs. static, priority ordering (video wins over gif+static, gif wins over static), monitor-name propagation (`ALL` vs. named `DP-1`), GNOME/KDE static-path fallback — passed throughout. Only the single mpvpaper-command-literal assertion per case failed, and always for the same reason (wrong expected string). Nothing about the module's video/gif/static priority logic, per-WM exec generation, or monitor targeting needed to change.

## Files changed

- `test-nixos-wallpapers/02-gif-no-waypaper_test.nix`
- `test-nixos-wallpapers/05-aarch64-gif-no-waypaper_test.nix`
- `test-nixos-wallpapers/12-video-no-waypaper_test.nix`
- `test-nixos-wallpapers/13-video-gif-static-priority_test.nix`
- `test-nixos-wallpapers/15-named-monitor-video_test.nix`
- `test-nixos-wallpapers/test-nixos-wallpapers-readme.md` — `## Checks` tables updated to match the corrected expected-command format

## Verification

- Full `test-nixos-wallpapers` suite (all 15 files) run via `nix-tests` — all assertions pass, including the 5 previously-failing files.
- Confirmed manually by the user against local test output.

No `modules/**` files were touched in this PR.
